### PR TITLE
Intern JSON list and object cells in the array-record cost matrix

### DIFF
--- a/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
@@ -138,6 +138,43 @@ def _cell_match(
 _UNHASHABLE = object()
 
 
+def _eq_key(value: Any) -> Any:
+    """Hashable snapshot of Python ``==`` for intern (not the string-cell rule).
+
+    JSON containers freeze to tagged tuples so intern keys stay plain hashable
+    values (no FrozenDict) and JSON-dump after replacing tuples with lists:
+    lists as ``("l", items...)`` in order, dicts as ``("d", sorted (key, value)
+    pairs)`` because ``dict ==`` is key-order independent. Nested strings stay
+    exact: ``["Moscow "]`` and ``["Moscow"]`` are different keys. The top-level
+    string branch of ``_cell_key`` still whitespace-folds. Anything that cannot
+    freeze (mixed incomparable dict keys, a set, ...) stays ``_UNHASHABLE`` so
+    that column falls back to pairwise compare.
+    """
+    if isinstance(value, list):
+        parts = tuple(_eq_key(item) for item in value)
+        if any(part is _UNHASHABLE for part in parts):
+            return _UNHASHABLE
+        return ("l", parts)
+    if isinstance(value, dict):
+        items: list[tuple[Any, Any]] = []
+        for key, item in value.items():
+            frozen_key = _eq_key(key)
+            frozen_item = _eq_key(item)
+            if frozen_key is _UNHASHABLE or frozen_item is _UNHASHABLE:
+                return _UNHASHABLE
+            items.append((frozen_key, frozen_item))
+        try:
+            items.sort()
+        except TypeError:
+            return _UNHASHABLE
+        return ("d", tuple(items))
+    try:
+        hash(value)
+    except TypeError:
+        return _UNHASHABLE
+    return ("v", value)
+
+
 def _cell_key(value: Any, field_schema: Any = None) -> Any:
     """Hashable interning key that mirrors ``_cell_match`` for non-fuzzy fields.
 
@@ -145,9 +182,10 @@ def _cell_key(value: Any, field_schema: Any = None) -> Any:
     whitespace-insensitively, everything else by ``==``). Strings are tagged
     apart from non-strings so a normalized string can never collide with a
     look-alike scalar, exactly as ``_cell_match`` keeps its str/str branch
-    distinct from the ``==`` fallback. Returns ``_UNHASHABLE`` for values that
-    cannot be interned (e.g. list/dict cells) -> caller scores that column
-    pairwise instead.
+    distinct from the ``==`` fallback. List and dict cells freeze to tagged
+    tuples of exact nested values so opaque JSON arrays and objects intern
+    the same way scalars already do. Returns ``_UNHASHABLE`` when a cell still
+    cannot be interned -> caller scores that column pairwise.
 
     When ``field_schema`` is a nullable-numeric shape, ``0`` / ``0.0`` collapse
     to ``None`` in the key so that null-vs-zero cells intern to the same slot,
@@ -157,6 +195,8 @@ def _cell_key(value: Any, field_schema: Any = None) -> Any:
         return ("s", _normalize_ws(value))
     if _is_nullable_numeric_field(field_schema):
         value = _normalize_nullable_numeric(value)
+    if isinstance(value, (list, dict)):
+        return _eq_key(value)
     try:
         hash(value)
     except TypeError:
@@ -174,8 +214,8 @@ def _intern_field(
 
     Equal cells (per ``_cell_match``) receive the same id, so a single
     broadcasted integer ``!=`` reproduces the per-pair mismatch test while
-    normalizing each cell once instead of once per pair. Returns ``None`` if any
-    cell is unhashable (caller falls back to pairwise for this field).
+    normalizing each cell once, not once per pair. Returns ``None`` if any
+    cell cannot be interned so the caller scores that column pairwise.
     """
     keymap: dict[Any, int] = {}
     out: list[np.ndarray] = []

--- a/tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+
+from extract_bench.evaluation.metrics.extract.array_record_match_metric import (
+    _UNHASHABLE,
+    _cell_key,
+    _intern_field,
+    _mismatch_cost_matrix,
+)
+
+
+def _jsonable_intern_key(key: object) -> object:
+    """Tuples -> lists so intern keys round-trip through ``json.dumps``."""
+    if isinstance(key, tuple):
+        return [_jsonable_intern_key(part) for part in key]
+    return key
+
+
+def test_cell_key_interns_json_containers_with_exact_nested_equality() -> None:
+    """Opaque JSON arrays and objects intern; nested strings keep exact ``==``."""
+    assert _cell_key(["Moscow", "Kyiv"]) is not _UNHASHABLE
+    assert _cell_key(["Moscow", "Kyiv"]) == _cell_key(["Moscow", "Kyiv"])
+    assert _cell_key(["Moscow", "Kyiv"]) != _cell_key(["Kyiv", "Moscow"])
+    assert _cell_key(["Moscow "]) != _cell_key(["Moscow"])
+    assert _cell_key("Moscow") != _cell_key(["Moscow"])
+    assert _cell_key(["Moscow"]) != _cell_key(("Moscow",))
+
+    assert _cell_key({"city": "Moscow"}) is not _UNHASHABLE
+    assert _cell_key({"b": 1, "a": 2}) == _cell_key({"a": 2, "b": 1})
+    assert _cell_key({"city": "Moscow "}) != _cell_key({"city": "Moscow"})
+    assert _cell_key({}) != _cell_key([])
+    assert _cell_key([{"city": "Moscow"}]) == _cell_key([{"city": "Moscow"}])
+    assert _cell_key([{"city": "Moscow"}]) != _cell_key([{"city": "Kyiv"}])
+
+    dumped = json.dumps(_jsonable_intern_key(_cell_key({"b": 1, "a": ["x", "y"]})))
+    assert json.loads(dumped) == ["d", [[["v", "a"], ["l", [["v", "x"], ["v", "y"]]]], [["v", "b"], ["v", 1]]]]
+
+
+def test_intern_field_list_column_matches_pairwise_mismatch_cost() -> None:
+    actual = [{"addr": ["a", "b"]}, {"addr": ["c"]}]
+    expected = [{"addr": ["c"]}, {"addr": ["a", "b"]}]
+    interned = _intern_field(actual, expected, "addr")
+    assert interned is not None
+    cost = _mismatch_cost_matrix(actual, expected, ["addr"], {})
+    assert cost[0, 1] == 0
+    assert cost[1, 0] == 0
+    assert cost[0, 0] == 1
+    assert cost[1, 1] == 1
+
+
+def test_intern_field_dict_column_matches_pairwise_mismatch_cost() -> None:
+    actual = [{"amount": {"amount": 4.5, "currency": "USD"}}, {"amount": {"amount": 1.0, "currency": "EUR"}}]
+    expected = [{"amount": {"currency": "EUR", "amount": 1.0}}, {"amount": {"currency": "USD", "amount": 4.5}}]
+    interned = _intern_field(actual, expected, "amount")
+    assert interned is not None
+    cost = _mismatch_cost_matrix(actual, expected, ["amount"], {})
+    assert cost[0, 1] == 0
+    assert cost[1, 0] == 0
+    assert cost[0, 0] == 1
+    assert cost[1, 1] == 1

--- a/tests/extract_bench/utils/test_gemini_pricing.py
+++ b/tests/extract_bench/utils/test_gemini_pricing.py
@@ -24,4 +24,3 @@ def test_gemini_context_cache_pricing_3_7_flash() -> None:
 
 def test_gemini_context_cache_pricing_3_6_flash() -> None:
     assert gemini_context_cache_pricing_per_million("gemini-3.6-flash") == (0.15, 1.00)
-


### PR DESCRIPTION
## Summary
- Columns whose cells are JSON arrays or objects (addresses, tag lists, amount objects, nested dicts) could not be interned, so the row-assignment cost matrix built those columns with a Python `n×m` cell-match loop.
- Freeze lists to tagged tuples in order, and dicts to tagged sorted `(key, value)` pairs of **exact** nested values. Nested strings stay exact equality; the top-level string intern path still whitespace-folds.
- Those columns stay on the vectorized integer cost matrix instead of falling back to pairwise Python compares.

## Test plan
- [x] `pytest tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py`
- New tests: list/dict intern keys, list vs tuple, dict key-order independence, nested whitespace stays significant, interned cost matches pairwise, intern keys JSON-roundtrip


Made with [Cursor](https://cursor.com)