### PR TITLE
Score nested object fields as individual extract cells

### DIFF
--- a/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
@@ -423,14 +423,25 @@ def as_rows(value: Any) -> list[Any]:
     return list(value) if is_value_sequence(value) else []
 
 
-def is_array_schema(field_schema: Mapping[str, Any], expected_value: Any) -> bool:
-    """True when this field is an array in the schema or the gold value is a list.
+def is_array_schema(field_schema: Any) -> bool:
+    """True when JSON Schema describes an array (incl. ``anyOf`` / ``oneOf`` / ``allOf``).
 
-    Does not walk ``anyOf`` / ``oneOf``; a combinator-wrapped array is still
-    detected from the gold list. Strings are not treated as arrays.
+    Combinator-wrapped arrays (``anyOf: [{type: array, items: ...}, {type: null}]``)
+    have no top-level ``type: array``; walk the same combinators as ``schema_items``.
+    Gold/pred values are not consulted — a list in the extraction does not make
+    a string field an array.
     """
-    field_type = field_schema.get("type")
-    return field_type == "array" or is_value_sequence(expected_value)
+    if not isinstance(field_schema, Mapping):
+        return False
+    raw = field_schema.get("type")
+    types = raw if isinstance(raw, list) else [raw]
+    if "array" in types or isinstance(field_schema.get("items"), dict):
+        return True
+    for key in ("anyOf", "oneOf", "allOf"):
+        for alt in field_schema.get(key) or []:
+            if is_array_schema(alt):
+                return True
+    return False
 
 
 def array_item_properties(field_schema: Any) -> Mapping[str, Any]:
@@ -446,26 +457,9 @@ def array_item_properties(field_schema: Any) -> Mapping[str, Any]:
     return schema_properties(schema_items(field_schema))
 
 
-def array_subfield_names(
-    field_schema: Mapping[str, Any],
-    expected_rows: Any,
-) -> Sequence[str]:
-    """Column names for one array of objects.
-
-    Prefer schema property order from ``array_item_properties``. If the schema
-    has no item properties (untyped list, or rows that are not objects), fall
-    back to the sorted union of gold row keys.
-    """
-    item_props = array_item_properties(field_schema)
-    if len(item_props) > 0:
-        return list(item_props.keys())
-    if is_value_sequence(expected_rows):
-        keys: set[str] = set()
-        for row in expected_rows:
-            if isinstance(row, Mapping):
-                keys.update(row.keys())
-        return sorted(keys)
-    return []
+def array_subfield_names(field_schema: Mapping[str, Any]) -> Sequence[str]:
+    """Column names for one array of objects, from ``items.properties`` only."""
+    return list(array_item_properties(field_schema).keys())
 
 
 def _score_array(
@@ -554,8 +548,8 @@ def compute_array_record_match_counts(
         field_schema = schema_props.get(field, {})
         expected_value = expected.get(field)
         actual_value = actual.get(field)
-        if is_array_schema(field_schema, expected_value):
-            subfield_names = array_subfield_names(field_schema, expected_value)
+        if is_array_schema(field_schema):
+            subfield_names = array_subfield_names(field_schema)
             if len(subfield_names) == 0:
                 continue
             field_schemas = array_item_properties(field_schema)

--- a/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
@@ -18,6 +18,7 @@ from extract_bench.evaluation.metrics.extract.json_subset_match import (
     normalize_date_string,
 )
 from extract_bench.inference.providers.extract.table_codegen.schema_utils import (
+    resolve_refs,
     schema_items,
     schema_properties,
 )
@@ -533,7 +534,8 @@ def compute_array_record_match_counts(
         expected = normalize_dates_deep(expected)
         actual = normalize_dates_deep(actual)
 
-    schema_props = schema_properties(data_schema or {})
+    resolved = resolve_refs(data_schema) if isinstance(data_schema, Mapping) else {}
+    schema_props = schema_properties(resolved)
     fuzzy = dict(DEFAULT_FUZZY_FIELD_THRESHOLDS if fuzzy_field_thresholds is None else fuzzy_field_thresholds)
 
     correct = 0

--- a/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict, deque
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeGuard
 
 import numpy as np
 from rapidfuzz import fuzz
@@ -15,6 +16,10 @@ from extract_bench.evaluation.metrics.extract.json_subset_match import (
     _is_nullable_numeric_field,
     _normalize_nullable_numeric,
     normalize_date_string,
+)
+from extract_bench.inference.providers.extract.table_codegen.schema_utils import (
+    schema_items,
+    schema_properties,
 )
 from extract_bench.schemas.evaluation import MetricValue
 
@@ -31,7 +36,7 @@ _WS_RE = re.compile(r"\s+", re.U)
 # NEVER be scored as extracted cells. Kept in sync with the codegen provider's
 # ``PROVENANCE_KEY`` (table_codegen/schema_utils.py): a record may carry
 # ``_provenance: {"page": N}`` for source attribution, which the validity gate tolerates
-# and these value metrics ignore (nested record subfields already come from the schema /
+# and these value metrics ignore (nested object-array subfields already come from the schema /
 # expected rows, so the only leak was the top-level union walk over actual keys).
 RESERVED_OUTPUT_KEYS: frozenset[str] = frozenset({"_provenance"})
 
@@ -72,13 +77,13 @@ def _normalize_text(value: str) -> str:
     return _WS_RE.sub(" ", _PUNCT_RE.sub(" ", value)).strip().lower()
 
 
-def _unwrap_value(value: Any) -> Any:
+def unwrap_value(value: Any) -> Any:
     if isinstance(value, dict) and set(value) == {"value"}:
         return value["value"]
     return value
 
 
-def _normalize_dates_deep(value: Any) -> Any:
+def normalize_dates_deep(value: Any) -> Any:
     """Canonicalize date-like strings to ISO format everywhere in a JSON value.
 
     Applied once to both sides up front (not per cell pair) so the n×m
@@ -89,13 +94,13 @@ def _normalize_dates_deep(value: Any) -> Any:
     if isinstance(value, str):
         return normalize_date_string(value)
     if isinstance(value, dict):
-        return {k: _normalize_dates_deep(v) for k, v in value.items()}
+        return {k: normalize_dates_deep(v) for k, v in value.items()}
     if isinstance(value, list):
-        return [_normalize_dates_deep(v) for v in value]
+        return [normalize_dates_deep(v) for v in value]
     return value
 
 
-def _normalize_ws(value: str) -> str:
+def normalize_ws(value: str) -> str:
     """Collapse internal whitespace runs so only inter-word spacing matters.
 
     Multi-line cells (postal addresses, wrapped headers) carry hard line breaks
@@ -111,11 +116,12 @@ def _normalize_ws(value: str) -> str:
     return _WS_RE.sub(" ", value).strip()
 
 
-def _cell_match(
+def cell_match(
     expected: Any,
     actual: Any,
     field: str,
-    fuzzy_field_thresholds: dict[str, float],
+    *,
+    fuzzy_field_thresholds: Mapping[str, float],
     field_schema: Any = None,
 ) -> bool:
     threshold = fuzzy_field_thresholds.get(field)
@@ -123,10 +129,12 @@ def _cell_match(
         expected_norm = _normalize_text(expected)
         actual_norm = _normalize_text(actual)
         return expected_norm == actual_norm or (
-            bool(expected_norm) and bool(actual_norm) and fuzz.ratio(expected_norm, actual_norm) >= threshold * 100.0
+            len(expected_norm) > 0
+            and len(actual_norm) > 0
+            and fuzz.ratio(expected_norm, actual_norm) >= threshold * 100.0
         )
     if isinstance(expected, str) and isinstance(actual, str):
-        return _normalize_ws(expected) == _normalize_ws(actual)
+        return normalize_ws(expected) == normalize_ws(actual)
     # Nullable numeric fields treat 0 / 0.0 and None as equivalent. Gated on
     # the JSON Schema shape so plain numeric fields keep strict semantics.
     if _is_nullable_numeric_field(field_schema):
@@ -175,13 +183,16 @@ def _eq_key(value: Any) -> Any:
     return ("v", value)
 
 
-def _cell_key(value: Any, field_schema: Any = None) -> Any:
-    """Hashable interning key that mirrors ``_cell_match`` for non-fuzzy fields.
+def _cell_key(
+    value: Any,
+    field_schema: Any = None,
+) -> Any:
+    """Hashable interning key that mirrors ``cell_match`` for non-fuzzy fields.
 
-    Two cells share a key iff ``_cell_match`` returns True (strings compared
+    Two cells share a key iff ``cell_match`` returns True (strings compared
     whitespace-insensitively, everything else by ``==``). Strings are tagged
     apart from non-strings so a normalized string can never collide with a
-    look-alike scalar, exactly as ``_cell_match`` keeps its str/str branch
+    look-alike scalar, exactly as ``cell_match`` keeps its str/str branch
     distinct from the ``==`` fallback. List and dict cells freeze to tagged
     tuples of exact nested values so opaque JSON arrays and objects intern
     the same way scalars already do. Returns ``_UNHASHABLE`` when a cell still
@@ -189,10 +200,10 @@ def _cell_key(value: Any, field_schema: Any = None) -> Any:
 
     When ``field_schema`` is a nullable-numeric shape, ``0`` / ``0.0`` collapse
     to ``None`` in the key so that null-vs-zero cells intern to the same slot,
-    matching the equality relaxation in ``_cell_match``.
+    matching the equality relaxation in ``cell_match``.
     """
     if isinstance(value, str):
-        return ("s", _normalize_ws(value))
+        return ("s", normalize_ws(value))
     if _is_nullable_numeric_field(field_schema):
         value = _normalize_nullable_numeric(value)
     if isinstance(value, (list, dict)):
@@ -205,14 +216,14 @@ def _cell_key(value: Any, field_schema: Any = None) -> Any:
 
 
 def _intern_field(
-    actual_list: list[Any],
-    expected_list: list[Any],
+    actual_list: Sequence[Any],
+    expected_list: Sequence[Any],
     field: str,
     field_schema: Any = None,
 ) -> tuple[np.ndarray, np.ndarray] | None:
     """Map each row's ``field`` cell to an int id shared across both sides.
 
-    Equal cells (per ``_cell_match``) receive the same id, so a single
+    Equal cells (per ``cell_match``) receive the same id, so a single
     broadcasted integer ``!=`` reproduces the per-pair mismatch test while
     normalizing each cell once, not once per pair. Returns ``None`` if any
     cell cannot be interned so the caller scores that column pairwise.
@@ -236,9 +247,8 @@ def _intern_field(
 
 def _row_match_key(
     row: Any,
-    subfields: list[str],
-    fuzzy_field_thresholds: dict[str, float],
-    field_schemas: dict[str, Any] | None = None,
+    subfields: Sequence[str],
+    field_schemas: Mapping[str, Any] | None = None,
 ) -> tuple[Any, ...] | None:
     """Hashable full-row key whose equality implies zero assignment cost."""
     row_dict = row if isinstance(row, dict) else {}
@@ -252,16 +262,20 @@ def _row_match_key(
     return tuple(parts)
 
 
-def _can_peel_exact_rows(subfields: list[str], fuzzy_field_thresholds: dict[str, float]) -> bool:
+def _can_peel_exact_rows(
+    subfields: Sequence[str],
+    fuzzy_field_thresholds: Mapping[str, float],
+) -> bool:
     return all(fuzzy_field_thresholds.get(field) is None for field in subfields)
 
 
-def _peel_exact_row_matches(
+def peel_exact_row_matches(
     actual_list: list[Any],
     expected_list: list[Any],
-    subfields: list[str],
-    fuzzy_field_thresholds: dict[str, float],
-    field_schemas: dict[str, Any] | None = None,
+    *,
+    subfields: Sequence[str],
+    fuzzy_field_thresholds: Mapping[str, float],
+    field_schemas: Mapping[str, Any] | None = None,
 ) -> _RowAssignment:
     """Pre-align zero-cost rows before building an expensive residual matrix.
 
@@ -278,7 +292,7 @@ def _peel_exact_row_matches(
 
     actual_by_key: defaultdict[tuple[Any, ...], deque[int]] = defaultdict(deque)
     for actual_idx, row in enumerate(actual_list):
-        key = _row_match_key(row, subfields, fuzzy_field_thresholds, field_schemas)
+        key = _row_match_key(row, subfields, field_schemas)
         if key is not None:
             actual_by_key[key].append(actual_idx)
 
@@ -286,7 +300,7 @@ def _peel_exact_row_matches(
     matched_actual: set[int] = set()
     unmatched_expected_indices: list[int] = []
     for expected_idx, row in enumerate(expected_list):
-        key = _row_match_key(row, subfields, fuzzy_field_thresholds, field_schemas)
+        key = _row_match_key(row, subfields, field_schemas)
         bucket = actual_by_key.get(key) if key is not None else None
         if bucket:
             actual_idx = bucket.popleft()
@@ -303,22 +317,23 @@ def _peel_exact_row_matches(
     )
 
 
-def _mismatch_cost_matrix(
+def mismatch_cost_matrix(
     actual_list: list[Any],
     expected_list: list[Any],
-    subfields: list[str],
-    fuzzy_field_thresholds: dict[str, float],
-    field_schemas: dict[str, Any] | None = None,
+    *,
+    subfields: Sequence[str],
+    fuzzy_field_thresholds: Mapping[str, float],
+    field_schemas: Mapping[str, Any] | None = None,
 ) -> np.ndarray:
     """Vectorized ``(n_actual, n_expected)`` matrix of mismatched-subfield counts.
 
-    Bit-identical to the per-pair ``sum(not _cell_match(...))`` build but without
+    Bit-identical to the per-pair ``sum(not cell_match(...))`` build but without
     the n*m*k Python loop: each exact-match subfield is interned to ints and
     compared with one broadcasted ``!=`` (each cell normalized once, not once per
     pair). Fuzzy fields and unhashable cells fall back to the original pairwise
     compare for that column only. The matrix is ``int16`` (counts are bounded by
-    ``len(subfields)``) -- 4x smaller than ``float64``, which bounds the build
-    time and memory of very large matrices.
+    ``len(subfields)``) -- a 4x smaller cost matrix than the old ``float64`` and
+    the change that lifts the giant-array build time and OOM.
     """
     na, ne = len(actual_list), len(expected_list)
     cost = np.zeros((na, ne), dtype=np.int16)
@@ -340,7 +355,13 @@ def _mismatch_cost_matrix(
             cost_row = cost[i]
             for j, expected_row in enumerate(expected_list):
                 expected_dict = expected_row if isinstance(expected_row, dict) else {}
-                if not _cell_match(expected_dict.get(field), actual_value, field, fuzzy_field_thresholds, field_schema):
+                if not cell_match(
+                    expected_dict.get(field),
+                    actual_value,
+                    field,
+                    fuzzy_field_thresholds=fuzzy_field_thresholds,
+                    field_schema=field_schema,
+                ):
                     cost_row[j] += 1
     return cost
 
@@ -348,13 +369,20 @@ def _mismatch_cost_matrix(
 def _assign_rows(
     actual_list: list[Any],
     expected_list: list[Any],
-    subfields: list[str],
-    fuzzy_field_thresholds: dict[str, float],
-    field_schemas: dict[str, Any] | None = None,
+    *,
+    subfields: Sequence[str],
+    fuzzy_field_thresholds: Mapping[str, float],
+    field_schemas: Mapping[str, Any] | None = None,
 ) -> list[tuple[int, int]]:
-    assignment = _peel_exact_row_matches(actual_list, expected_list, subfields, fuzzy_field_thresholds, field_schemas)
+    assignment = peel_exact_row_matches(
+        actual_list,
+        expected_list,
+        subfields=subfields,
+        fuzzy_field_thresholds=fuzzy_field_thresholds,
+        field_schemas=field_schemas,
+    )
     pairs = list(assignment.pairs)
-    if not assignment.unmatched_actual_indices or not assignment.unmatched_expected_indices:
+    if len(assignment.unmatched_actual_indices) == 0 or len(assignment.unmatched_expected_indices) == 0:
         return pairs
 
     residual_actual = [actual_list[idx] for idx in assignment.unmatched_actual_indices]
@@ -368,28 +396,73 @@ def _assign_rows(
     # misses) rather than crashing the whole run -- a peel-only lower bound.
     if len(residual_actual) * len(residual_expected) > _MAX_RESIDUAL_ASSIGNMENT_CELLS:
         return pairs
-    cost = _mismatch_cost_matrix(residual_actual, residual_expected, subfields, fuzzy_field_thresholds, field_schemas)
+    cost = mismatch_cost_matrix(
+        residual_actual,
+        residual_expected,
+        subfields=subfields,
+        fuzzy_field_thresholds=fuzzy_field_thresholds,
+        field_schemas=field_schemas,
+    )
     row_ind, col_ind = linear_sum_assignment(cost)
     pairs.extend(
-        (assignment.unmatched_actual_indices[int(actual_idx)], assignment.unmatched_expected_indices[int(expected_idx)])
+        (
+            assignment.unmatched_actual_indices[int(actual_idx)],
+            assignment.unmatched_expected_indices[int(expected_idx)],
+        )
         for actual_idx, expected_idx in zip(row_ind, col_ind, strict=True)
     )
     return pairs
 
 
-def _is_array_schema(field_schema: dict[str, Any], expected_value: Any) -> bool:
+def is_value_sequence(value: Any) -> TypeGuard[Sequence[Any]]:
+    """List-like JSON arrays, not ``str`` / ``bytes`` (those are Sequences too)."""
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes))
+
+
+def as_rows(value: Any) -> list[Any]:
+    return list(value) if is_value_sequence(value) else []
+
+
+def is_array_schema(field_schema: Mapping[str, Any], expected_value: Any) -> bool:
+    """True when this field is an array in the schema or the gold value is a list.
+
+    Does not walk ``anyOf`` / ``oneOf``; a combinator-wrapped array is still
+    detected from the gold list. Strings are not treated as arrays.
+    """
     field_type = field_schema.get("type")
-    return field_type == "array" or isinstance(expected_value, list)
+    return field_type == "array" or is_value_sequence(expected_value)
 
 
-def _array_subfields(field_schema: dict[str, Any], expected_rows: Any) -> list[str]:
-    item_props = field_schema.get("items", {}).get("properties", {})
-    if item_props:
+def array_item_properties(field_schema: Any) -> Mapping[str, Any]:
+    """Column schemas for an array of objects: ``items.properties``, combinators flattened.
+
+    ``field_schema`` is the array node (possibly ``anyOf`` [array, null]). Same
+    ``schema_items`` / ``schema_properties`` helpers as extract GT lint. ``$ref``
+    is not followed; callers inline with ``resolve_refs`` first. The mapping is
+    not owned by the caller; do not mutate it.
+    """
+    if not isinstance(field_schema, Mapping):
+        return {}
+    return schema_properties(schema_items(field_schema))
+
+
+def array_subfield_names(
+    field_schema: Mapping[str, Any],
+    expected_rows: Any,
+) -> Sequence[str]:
+    """Column names for one array of objects.
+
+    Prefer schema property order from ``array_item_properties``. If the schema
+    has no item properties (untyped list, or rows that are not objects), fall
+    back to the sorted union of gold row keys.
+    """
+    item_props = array_item_properties(field_schema)
+    if len(item_props) > 0:
         return list(item_props.keys())
-    if isinstance(expected_rows, list):
+    if is_value_sequence(expected_rows):
         keys: set[str] = set()
         for row in expected_rows:
-            if isinstance(row, dict):
+            if isinstance(row, Mapping):
                 keys.update(row.keys())
         return sorted(keys)
     return []
@@ -398,43 +471,54 @@ def _array_subfields(field_schema: dict[str, Any], expected_rows: Any) -> list[s
 def _score_array(
     expected_rows: Any,
     actual_rows: Any,
-    subfields: list[str],
-    fuzzy_field_thresholds: dict[str, float],
-    field_schemas: dict[str, Any] | None = None,
+    *,
+    subfields: Sequence[str],
+    fuzzy_field_thresholds: Mapping[str, float],
+    field_schemas: Mapping[str, Any] | None = None,
 ) -> tuple[int, int, int, int, int]:
-    expected_list = expected_rows if isinstance(expected_rows, list) else []
-    actual_list = actual_rows if isinstance(actual_rows, list) else []
+    expected_list = as_rows(expected_rows)
+    actual_list = as_rows(actual_rows)
     expected_total = len(expected_list) * len(subfields)
     predicted_total = len(actual_list) * len(subfields)
 
-    if not expected_list or not subfields or not actual_list:
+    if len(expected_list) == 0 or len(subfields) == 0 or len(actual_list) == 0:
         return 0, expected_total, predicted_total, len(expected_list), len(actual_list)
 
     correct = 0
     for actual_idx, expected_idx in _assign_rows(
-        actual_list, expected_list, subfields, fuzzy_field_thresholds, field_schemas
+        actual_list,
+        expected_list,
+        subfields=subfields,
+        fuzzy_field_thresholds=fuzzy_field_thresholds,
+        field_schemas=field_schemas,
     ):
-        actual_dict = actual_list[actual_idx] if isinstance(actual_list[actual_idx], dict) else {}
-        expected_dict = expected_list[expected_idx] if isinstance(expected_list[expected_idx], dict) else {}
+        actual_dict = actual_list[actual_idx] if isinstance(actual_list[actual_idx], Mapping) else {}
+        expected_dict = expected_list[expected_idx] if isinstance(expected_list[expected_idx], Mapping) else {}
         correct += sum(
-            _cell_match(
+            cell_match(
                 expected_dict.get(field),
                 actual_dict.get(field),
                 field,
-                fuzzy_field_thresholds,
-                (field_schemas or {}).get(field),
+                fuzzy_field_thresholds=fuzzy_field_thresholds,
+                field_schema=(field_schemas or {}).get(field),
             )
             for field in subfields
         )
 
-    return correct, expected_total, predicted_total, len(expected_list), len(actual_list)
+    return (
+        correct,
+        expected_total,
+        predicted_total,
+        len(expected_list),
+        len(actual_list),
+    )
 
 
 def compute_array_record_match_counts(
     expected: Any,
     actual: Any,
-    data_schema: dict[str, Any] | None = None,
-    fuzzy_field_thresholds: dict[str, float] | None = None,
+    data_schema: Mapping[str, Any] | None = None,
+    fuzzy_field_thresholds: Mapping[str, float] | None = None,
     normalize_dates: bool = True,
 ) -> ArrayRecordMatchCounts | None:
     """Compute order-insensitive record matching counts for top-level arrays.
@@ -447,15 +531,15 @@ def compute_array_record_match_counts(
     sides are canonicalized to ISO format before comparison, aligned with the
     generic ``accuracy`` metric (json_subset_match).
     """
-    expected = _unwrap_value(expected)
-    actual = _unwrap_value(actual)
-    if not isinstance(expected, dict) or not isinstance(actual, dict):
+    expected = unwrap_value(expected)
+    actual = unwrap_value(actual)
+    if not isinstance(expected, Mapping) or not isinstance(actual, Mapping):
         return None
     if normalize_dates:
-        expected = _normalize_dates_deep(expected)
-        actual = _normalize_dates_deep(actual)
+        expected = normalize_dates_deep(expected)
+        actual = normalize_dates_deep(actual)
 
-    schema_props = (data_schema or {}).get("properties", {})
+    schema_props = schema_properties(data_schema or {})
     fuzzy = dict(DEFAULT_FUZZY_FIELD_THRESHOLDS if fuzzy_field_thresholds is None else fuzzy_field_thresholds)
 
     correct = 0
@@ -470,19 +554,24 @@ def compute_array_record_match_counts(
         field_schema = schema_props.get(field, {})
         expected_value = expected.get(field)
         actual_value = actual.get(field)
-        if _is_array_schema(field_schema, expected_value):
-            subfields = _array_subfields(field_schema, expected_value)
-            if not subfields:
+        if is_array_schema(field_schema, expected_value):
+            subfield_names = array_subfield_names(field_schema, expected_value)
+            if len(subfield_names) == 0:
                 continue
-            item_props = field_schema.get("items", {}).get("properties", {}) if isinstance(field_schema, dict) else {}
-            field_schemas = item_props if isinstance(item_props, dict) else {}
+            field_schemas = array_item_properties(field_schema)
             (
                 array_correct,
                 array_expected_total,
                 array_predicted_total,
                 array_expected_rows,
                 array_predicted_rows,
-            ) = _score_array(expected_value, actual_value, subfields, fuzzy, field_schemas)
+            ) = _score_array(
+                expected_value,
+                actual_value,
+                subfields=subfield_names,
+                fuzzy_field_thresholds=fuzzy,
+                field_schemas=field_schemas,
+            )
             correct += array_correct
             expected_total += array_expected_total
             predicted_total += array_predicted_total
@@ -493,11 +582,17 @@ def compute_array_record_match_counts(
             expected_total += 1
             # An omitted key is an implicit null prediction and always counts in
             # the precision denominator (an omitted GT-null field matches via
-            # ``_cell_match(None, None)``, so gating on ``field in actual`` let
+            # ``cell_match(None, None)``, so gating on ``field in actual`` let
             # correct exceed predicted_total and precision run past 1.0).
             predicted_total += 1
             scalar_fields_scored += 1
-            if _cell_match(expected_value, actual_value, field, fuzzy, field_schema):
+            if cell_match(
+                expected_value,
+                actual_value,
+                field,
+                fuzzy_field_thresholds=fuzzy,
+                field_schema=field_schema,
+            ):
                 correct += 1
 
     if arrays_scored == 0 or expected_total <= 0:
@@ -517,7 +612,11 @@ def compute_array_record_match_counts(
 class ArrayRecordMatchMetric:
     """Metric bundle for long-array extraction quality."""
 
-    def __init__(self, fuzzy_field_thresholds: dict[str, float] | None = None, normalize_dates: bool = True):
+    def __init__(
+        self,
+        fuzzy_field_thresholds: Mapping[str, float] | None = None,
+        normalize_dates: bool = True,
+    ):
         self._fuzzy_field_thresholds = fuzzy_field_thresholds
         self._normalize_dates = normalize_dates
 
@@ -572,8 +671,16 @@ class ArrayRecordMatchMetric:
                     "denominator": "expected_data_points",
                 },
             ),
-            MetricValue(metric_name="array_record_precision", value=precision, metadata=prf_metadata),
-            MetricValue(metric_name="array_record_recall", value=recall, metadata=prf_metadata),
+            MetricValue(
+                metric_name="array_record_precision",
+                value=precision,
+                metadata=prf_metadata,
+            ),
+            MetricValue(
+                metric_name="array_record_recall",
+                value=recall,
+                metadata=prf_metadata,
+            ),
             MetricValue(metric_name="array_record_f1", value=f1, metadata=prf_metadata),
             MetricValue(
                 metric_name="array_record_row_count_ratio",

--- a/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
@@ -82,7 +82,6 @@ from extract_bench.evaluation.metrics.extract.array_record_match_metric import (
     as_rows,
     cell_match,
     is_array_schema,
-    is_value_sequence,
     mismatch_cost_matrix,
     normalize_dates_deep,
     normalize_ws,
@@ -291,42 +290,31 @@ def is_object_array_schema(field_schema: Any) -> bool:
     return "object" in types
 
 
-def _row_has_object_list(rows: Sequence[Any], sub: str) -> bool:
-    for row in rows:
-        if isinstance(row, Mapping):
-            value = row.get(sub)
-            if is_value_sequence(value) and len(value) > 0 and isinstance(value[0], Mapping):
+def is_object_schema(field_schema: Any) -> bool:
+    """True when JSON Schema describes an object (incl. combinators)."""
+    if not isinstance(field_schema, Mapping):
+        return False
+    if len(schema_properties(field_schema)) > 0:
+        return True
+    raw = field_schema.get("type")
+    types = raw if isinstance(raw, list) else [raw]
+    if "object" in types:
+        return True
+    for key in ("anyOf", "oneOf", "allOf"):
+        for alt in field_schema.get(key) or []:
+            if is_object_schema(alt):
                 return True
     return False
 
 
-def is_object_array_subfield(
-    rows: Sequence[Any],
-    sub: str,
-    extra_rows: Sequence[Any] | None = None,
-    field_schema: Any = None,
-) -> bool:
-    """True when ``sub`` is a nested object-array (Hungarian at the next depth).
-
-    Distinct from ``is_object_subfield`` (a single dict on the row). Scalar
-    lists stay opaque cells. Empty or null gold still counts when the item
-    schema is an object or the prediction already holds a list of objects —
-    otherwise invented rows collapse to one opaque miss.
-    """
-    if is_object_array_schema(field_schema):
-        return True
-    if _row_has_object_list(rows, sub):
-        return True
-    return extra_rows is not None and _row_has_object_list(extra_rows, sub)
+def is_object_array_subfield(field_schema: Any) -> bool:
+    """True when the field schema is a nested object-array (Hungarian at the next depth)."""
+    return is_object_array_schema(field_schema)
 
 
-def is_object_subfield(exp_rows: Sequence[Any], act_rows: Sequence[Any], sub: str) -> bool:
-    """True when ``sub`` is a dict on any gold or pred row (scored via ``_score_node``)."""
-    for rows in (exp_rows, act_rows):
-        for row in rows:
-            if isinstance(row, Mapping) and isinstance(row.get(sub), Mapping):
-                return True
-    return False
+def is_object_subfield(field_schema: Any) -> bool:
+    """True when the field schema is a dict (scored via ``_score_node``)."""
+    return is_object_schema(field_schema)
 
 
 def iou_xywh(a: BBox, b: BBox) -> float:
@@ -433,22 +421,24 @@ class Scorer:
         missing partner as implicit ``null`` children and can *match* gold
         nulls. There is no partner row here, so every leaf is a one-sided miss.
         """
-        if isinstance(value, Mapping):
-            props = schema_properties(schema)
-            keys = sorted(value.keys())
-            if len(keys) > 0:
-                for key in keys:
-                    child = f"{path}.{key}" if path else key
-                    self._count_subtree(child, value[key], props.get(key, {}), c, expected=expected)
+        if is_array_schema(schema):
+            if is_object_array_schema(schema):
+                subfield_names = array_subfield_names(schema)
+                item_sch = array_item_properties(schema)
+                for i, row in enumerate(as_rows(value)):
+                    rd = row if isinstance(row, Mapping) else {}
+                    for s in subfield_names:
+                        self._count_subtree(f"{path}[{i}].{s}", rd.get(s), item_sch.get(s, {}), c, expected=expected)
                 return
-        if is_value_sequence(value) and any(isinstance(r, Mapping) for r in value):
-            subfield_names = array_subfield_names(schema, value)
-            item_sch = array_item_properties(schema)
-            for i, row in enumerate(value):
-                rd = row if isinstance(row, Mapping) else {}
-                for s in subfield_names:
-                    self._count_subtree(f"{path}[{i}].{s}", rd.get(s), item_sch.get(s, {}), c, expected=expected)
-        elif expected:
+        elif is_object_schema(schema):
+            props = schema_properties(schema)
+            if len(props) > 0:
+                rd = value if isinstance(value, Mapping) else {}
+                for key, child_schema in props.items():
+                    child = f"{path}.{key}" if path else key
+                    self._count_subtree(child, rd.get(key), child_schema, c, expected=expected)
+                return
+        if expected:
             c.expected += 1
             self._note_grounded_expected(path, c)
             if self._ev_pages.get(path):
@@ -481,20 +471,16 @@ class Scorer:
         # threading both is what keeps nested grounding correct after a remap.
         exp_rows = as_rows(exp_rows)
         act_rows = as_rows(act_rows)
-        subfield_names = array_subfield_names(schema, exp_rows)
+        subfield_names = array_subfield_names(schema)
         if len(subfield_names) == 0:
             return
         item_sch = array_item_properties(schema)
         # List-of-objects subfields recurse with another Hungarian pass.
         # Dict-valued subfields recurse via ``_score_node`` (same as root).
         # Scalars and scalar lists stay opaque cells.
-        object_array_names = [
-            s
-            for s in subfield_names
-            if is_object_array_subfield(exp_rows, s, extra_rows=act_rows, field_schema=item_sch.get(s, {}))
-        ]
+        object_array_names = [s for s in subfield_names if is_object_array_subfield(item_sch.get(s, {}))]
         object_names = [
-            s for s in subfield_names if s not in object_array_names and is_object_subfield(exp_rows, act_rows, s)
+            s for s in subfield_names if s not in object_array_names and is_object_subfield(item_sch.get(s, {}))
         ]
         cell_names = [s for s in subfield_names if s not in object_array_names and s not in object_names]
         # Opaque-cell denominators: array_record-exact (rows x cell subfields).
@@ -731,23 +717,21 @@ class Scorer:
     def _score_node(
         self, gt_path: str, pred_path: str, ev: Any, av: Any, schema: Mapping[str, Any], c: _Counts
     ) -> None:
-        if is_array_schema(schema, ev):
+        if is_array_schema(schema):
             self._score_array(gt_path, pred_path, ev, av, schema, c)
             return
-        ev_obj = isinstance(ev, Mapping)
-        av_obj = isinstance(av, Mapping)
-        if ev_obj or av_obj:
+        if is_object_schema(schema):
             props = schema_properties(schema)
-            ed = ev if ev_obj else {}
-            ad = av if av_obj else {}
-            keys = sorted(set(ed) | set(ad))
+            ed = ev if isinstance(ev, Mapping) else {}
+            ad = av if isinstance(av, Mapping) else {}
+            keys = list(props.keys())
             if len(keys) == 0:
                 self._score_scalar_cell(gt_path, pred_path, ev, av, c)
                 return
             for key in keys:
                 child_gt = f"{gt_path}.{key}" if gt_path else key
                 child_pred = f"{pred_path}.{key}" if pred_path else key
-                self._score_node(child_gt, child_pred, ed.get(key), ad.get(key), props.get(key, {}), c)
+                self._score_node(child_gt, child_pred, ed.get(key), ad.get(key), props[key], c)
             return
         self._score_scalar_cell(gt_path, pred_path, ev, av, c)
 

--- a/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
@@ -15,13 +15,13 @@ three additions:
    matches its ``expected_output`` value *or any* alternate value declared in
    that leaf's ``evidence[]``. (When a leaf has a single evidence value equal to
    the expected value, this is just ``array_record``.)
-2. **Sub-record recursion.** A list-of-objects subfield (e.g. OFAC
-   ``entities[].aliases``) is recursed into and aligned per sub-row, scoring
-   each of its fields, instead of being compared as one opaque cell.
-   Scalars, scalar lists, and **bare objects stay opaque cells** -- an
-   object-valued cell is scored all-or-nothing, NOT field-by-field, so this is
-   not universal leaf-level scoring for object-valued cells (that would diverge
-   from array_record's structure).
+2. **Object and object-array recursion.** A list-of-objects subfield (e.g. OFAC
+   ``entities[].aliases``) is recursed into and aligned with another Hungarian
+   pass, scoring each of its fields, instead of being compared as one opaque
+   cell. Bare objects (root, nested outside arrays, and objects on array rows)
+   are recursed into and scored per child cell with the same ``.get`` lookup the
+   root object uses; omit vs a gold object is implicit ``null`` children, not
+   one all-or-nothing miss. Scalar lists stay opaque.
 3. **Grounding (bbox + page).** Two parallel sets of counters, both value-gated
    and both nesting under the value score. A cell is *grounded-correct* when the
    value matches AND the prediction's citation has a bbox that overlaps an
@@ -32,7 +32,8 @@ three additions:
    per-cell superset of bbox (a box match requires equal pages, and page
    evidence/claims are supersets of bbox evidence/claims), so the three F1s nest:
    ``value_f1 >= page_f1 >= grounded_f1``. Together ``*_grounded_*`` and
-   ``*_page_*`` form one nested precision/recall/F1 trio.
+   ``*_page_*`` replace the old ``extract_evidence_bbox_*`` and
+   ``extract_evidence_page_*`` families as one nested precision/recall/F1 trio.
    Grounding is only defined where the GT carries the corresponding annotation
    (a page for ``*_page_*``, a bbox for ``*_grounded_*``), on
    BOTH sides of the P/R pair: recall's denominator is the GT cells that carry
@@ -47,11 +48,13 @@ three additions:
    metric (excluded from the dataset average), rather than a 0.0 that would
    punish a document that simply cannot be graded for grounding.
 
-On a document with no object-array subfields and no alternate evidence values,
-the ``*_value_*`` metrics are bit-identical to ``array_record_*`` -- same
-alignment, subfields, cost matrix, and denominators -- with no ``match_by`` rule
-anywhere. Object-array subfields make the value metrics diverge upward (the
-per-sub-record credit array_record cannot give); the ``*_grounded_*`` metrics
+On a document with no object-array subfields, no object-valued cells, and no
+alternate evidence values, the ``*_value_*`` metrics are bit-identical to
+``array_record_*`` -- same alignment, subfields, cost matrix, and denominators
+-- with no ``match_by`` rule anywhere. Object-array subfields and objects
+recursed as child cells
+make the value metrics diverge from array_record (per-child credit); the
+``*_grounded_*`` metrics
 are the other new signal (0 for pipelines that emit no citations *on documents
 whose GT carries bboxes*; omitted entirely on documents whose GT has none).
 Truncation
@@ -63,9 +66,10 @@ pass.
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Any
+from typing import Any, SupportsFloat
 
 import numpy as np
 from scipy.optimize import linear_sum_assignment
@@ -73,16 +77,23 @@ from scipy.optimize import linear_sum_assignment
 from extract_bench.evaluation.metrics.extract.array_record_match_metric import (
     DEFAULT_FUZZY_FIELD_THRESHOLDS,
     RESERVED_OUTPUT_KEYS,
-    _array_subfields,
-    _cell_match,
-    _is_array_schema,
-    _mismatch_cost_matrix,
-    _normalize_dates_deep,
-    _normalize_ws,
-    _peel_exact_row_matches,
-    _unwrap_value,
+    array_item_properties,
+    array_subfield_names,
+    as_rows,
+    cell_match,
+    is_array_schema,
+    is_value_sequence,
+    mismatch_cost_matrix,
+    normalize_dates_deep,
+    normalize_ws,
+    peel_exact_row_matches,
+    unwrap_value,
 )
 from extract_bench.evaluation.metrics.extract.json_subset_match import normalize_date_string
+from extract_bench.inference.providers.extract.table_codegen.schema_utils import (
+    resolve_refs,
+    schema_properties,
+)
 from extract_bench.schemas.evaluation import MetricValue
 from extract_bench.test_cases.schema import ExtractFieldTestRule, iter_rule_evidence
 
@@ -97,14 +108,18 @@ _NULL_EQUALS_FALSE = "null_equals_false"
 _PHONE_DIGITS = "phone_digits"
 _LENIENT_DATE = "lenient_date"
 _PUNCTUATION_SPACING = "punctuation_spacing"
-# Above this many cells (GT rows x predicted rows) in one flat array, the
+# Above this many cells (GT rows x predicted rows) in a single flat array, the
 # grounded assignment matrix -- an int16 cost matrix plus scipy's internal
-# float64 copy -- is several GB and a memory-limited runner OOMs building it.
-# Such an array skips grounding entirely (``grounded_incomplete``) rather than
-# scoring it partially, and the value score takes the exact-row peel, which is
-# value-identical for opaque un-grounded cells. Only arrays with no sub-records
-# qualify, so the peel never shifts nested TP. 100M cells keeps the matrix under
-# ~1 GB while sparing every ordinary document.
+# float64 copy -- is several GB, and a memory-limited eval runner OOMs building
+# it. For such an array we SKIP grounding (its bbox metrics), which lets the
+# value score take the exact-row peel that is provably value-identical for
+# opaque un-grounded cells (the pairing the full matrix would have chosen only
+# matters for grounded/nested TP, which we are not scoring). The document then
+# emits NO grounded metric at all (``grounded_incomplete``), rather than a
+# partial grounded score. Only arrays with no nested object or object-array
+# subfields qualify, so the peel
+# never shifts nested TP. ~100M cells keeps the matrix
+# under ~1 GB while sparing every ordinary document.
 _GROUNDED_MAX_CELLS = 100_000_000
 # Everything ``configured_cell_match`` handles; kept equal to the schema's
 # EXTRACT_FIELD_NORMALIZERS vocabulary (guarded by a unit test) so a name can't
@@ -132,6 +147,18 @@ _DIGIT_RE = re.compile(r"\d")
 _SPLIT_YEAR_RE = re.compile(r"\b(19|20)\s+(\d{2})\b")
 _TRAILING_2DIGIT_YEAR_RE = re.compile(r"^(.*[ ,/-])(\d{2})\s*$")
 _ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# Validated COCO xywh after ingest. JSON / Pydantic still carry list[float].
+type BBox = tuple[float, float, float, float]
+type PageBBox = tuple[int, BBox]
+type BoxIndex = dict[str, list[PageBBox]]
+
+
+def _validated_bbox(raw: Sequence[SupportsFloat]) -> BBox | None:
+    """Four COCO xywh floats, or None when the payload is shorter than xywh."""
+    if len(raw) < 4:
+        return None
+    return (float(raw[0]), float(raw[1]), float(raw[2]), float(raw[3]))
 
 
 @lru_cache(maxsize=8192)
@@ -166,11 +193,12 @@ def configured_cell_match(
     expected: Any,
     actual: Any,
     field: str,
+    *,
     fuzzy: dict[str, float],
     normalizers: tuple[str, ...] | None,
 ) -> bool:
-    """``_cell_match`` plus the field's opt-in normalizer fallbacks."""
-    if _cell_match(expected, actual, field, fuzzy):
+    """``cell_match`` plus the field's opt-in normalizer fallbacks."""
+    if cell_match(expected, actual, field, fuzzy_field_thresholds=fuzzy):
         return True
     if not normalizers:
         return False
@@ -187,15 +215,15 @@ def configured_cell_match(
         # Both sides must survive the strip: punctuation-only values ('.' vs
         # ';') would otherwise collapse to '' == '' and match each other.
         if expected_norm and actual_norm:
-            if _cell_match(expected_norm, actual_norm, field, fuzzy):
+            if cell_match(expected_norm, actual_norm, field, fuzzy_field_thresholds=fuzzy):
                 return True
     if _PUNCTUATION_SPACING in normalizers:
         expected_norm = _PUNCT_SPACING_RE.sub(r"\1", expected)
         actual_norm = _PUNCT_SPACING_RE.sub(r"\1", actual)
-        if _cell_match(expected_norm, actual_norm, field, fuzzy):
+        if cell_match(expected_norm, actual_norm, field, fuzzy_field_thresholds=fuzzy):
             return True
     if _CASE_INSENSITIVE in normalizers:
-        if _normalize_ws(expected).casefold() == _normalize_ws(actual).casefold():
+        if normalize_ws(expected).casefold() == normalize_ws(actual).casefold():
             return True
     if _PHONE_DIGITS in normalizers:
         expected_digits = _NON_DIGIT_RE.sub("", expected)
@@ -239,39 +267,61 @@ class _Counts:
     value_incomplete: bool = False  # a giant flat array skipped the residual value matrix -> value is a lower bound
 
 
-def _is_record_subfield(rows: list[Any], sub: str) -> bool:
-    """True when a subfield holds a list of objects in any row (a real sub-record).
+def path_leaf(path: str) -> str:
+    """Last field name on an extract path, with a trailing array index stripped.
 
-    Scalar lists (footnote markers, tag strings) and bare objects are NOT
-    sub-records: they stay opaque cells scored exactly as array_record does, so
-    a doc with no object-array subfields reduces to array_record bit-for-bit.
+    ``holdings[0].security`` → ``security``; ``rows[2]`` → ``rows``. Used as the
+    ``field`` key for fuzzy / cell-match lookup when scoring a scalar at ``path``.
+    """
+    return path.rsplit(".", 1)[-1].split("[", 1)[0]
+
+
+def is_object_array_subfield(rows: Sequence[Any], sub: str) -> bool:
+    """True when ``sub`` is a list of objects on any row (nested Hungarian).
+
+    Distinct from ``is_object_subfield`` (a single dict on the row). Scalar
+    lists stay opaque cells.
     """
     for row in rows:
-        if isinstance(row, dict):
+        if isinstance(row, Mapping):
             value = row.get(sub)
-            if isinstance(value, list) and value and isinstance(value[0], dict):
+            if is_value_sequence(value) and len(value) > 0 and isinstance(value[0], Mapping):
                 return True
     return False
 
 
-def _iou_xywh(a: list[float], b: list[float]) -> float:
-    ax, ay, aw, ah = a[0], a[1], a[2], a[3]
-    bx, by, bw, bh = b[0], b[1], b[2], b[3]
+def is_object_subfield(exp_rows: Sequence[Any], act_rows: Sequence[Any], sub: str) -> bool:
+    """True when ``sub`` is a dict on any gold or pred row (scored via ``_score_node``)."""
+    for rows in (exp_rows, act_rows):
+        for row in rows:
+            if isinstance(row, Mapping) and isinstance(row.get(sub), Mapping):
+                return True
+    return False
+
+
+def iou_xywh(a: BBox, b: BBox) -> float:
+    ax, ay, aw, ah = a
+    bx, by, bw, bh = b
     ix = max(0.0, min(ax + aw, bx + bw) - max(ax, bx))
     iy = max(0.0, min(ay + ah, by + bh) - max(ay, by))
     inter = ix * iy
     union = aw * ah + bw * bh - inter
-    return inter / union if union > 0 else 0.0
+    if union <= 0:
+        return 0.0
+    # Reconstructing width as (x+w)-x is a few ulps off for values like 0.1,
+    # so the raw ratio can exceed 1.0 even for identical boxes.
+    return min(1.0, inter / union)
 
 
-class _Scorer:
+class Scorer:
     def __init__(
         self,
+        *,
         alt_values: dict[str, list[Any]],
-        evidence_boxes: dict[str, list[tuple[int, list[float]]]],
+        evidence_boxes: BoxIndex,
         evidence_pages: dict[str, set[int]],
         normalizers: dict[str, tuple[str, ...]],
-        pred_boxes: dict[str, list[tuple[int, list[float]]]],
+        pred_boxes: BoxIndex,
         pred_pages: dict[str, set[int]],
         fuzzy: dict[str, float],
         iou_threshold: float,
@@ -286,7 +336,9 @@ class _Scorer:
         self._iou = iou_threshold
 
     def _configured_cell_match(self, gt_path: str, expected: Any, actual: Any, field: str) -> bool:
-        return configured_cell_match(expected, actual, field, self._fuzzy, self._normalizers.get(gt_path))
+        return configured_cell_match(
+            expected, actual, field, fuzzy=self._fuzzy, normalizers=self._normalizers.get(gt_path)
+        )
 
     def _value_match(self, gt_path: str, canonical: Any, actual: Any, field: str) -> bool:
         """OR-acceptable: the prediction matches the expected value or any evidence value."""
@@ -300,7 +352,17 @@ class _Scorer:
         pred = self._pred_boxes.get(pred_path)
         if not gt_boxes or not pred:
             return False
-        return any(gp == pp and _iou_xywh(gb, pb) >= self._iou for gp, gb in gt_boxes for pp, pb in pred)
+        return any(gp == pp and iou_xywh(gb, pb) >= self._iou for gp, gb in gt_boxes for pp, pb in pred)
+
+    def _note_grounded_expected(self, path: str, c: _Counts) -> None:
+        if self._ev_boxes.get(path):
+            c.g_expected += 1
+
+    def _note_grounded_claim(self, gt_path: str, pred_path: str, c: _Counts) -> None:
+        if not self._pred_boxes.get(pred_path):
+            return
+        if self._ev_boxes.get(gt_path):
+            c.g_claims += 1
 
     def _page_match(self, gt_path: str, pred_path: str) -> bool:
         """A cited page for pred_path lands in the GT evidence's page set for
@@ -324,29 +386,41 @@ class _Scorer:
         not be counted here or the grounded/page precision/recall would be
         computed against a truncated denominator).
         """
-        if self._value_match(gt_path, canonical, actual, field):
+        matched = self._value_match(gt_path, canonical, actual, field)
+        if matched:
             c.v_correct += 1
             if ground:
                 if self._box_match(gt_path, pred_path):
                     c.g_correct += 1
                 if self._page_match(gt_path, pred_path):
                     c.p_correct += 1
-            return True
-        return False
+        return matched
 
-    def _count_subtree(self, path: str, value: Any, schema: dict[str, Any], c: _Counts, *, expected: bool) -> None:
-        """Count an unmatched subtree's leaves on one side only (recall or precision miss)."""
-        if isinstance(value, list) and any(isinstance(r, dict) for r in value):
-            subs = _array_subfields(schema if isinstance(schema, dict) else {}, value)
-            item_sch = (schema or {}).get("items", {}).get("properties", {})
+    def _count_subtree(self, path: str, value: Any, schema: Mapping[str, Any], c: _Counts, *, expected: bool) -> None:
+        """Count an unmatched subtree's leaves on one side only (recall or precision miss).
+
+        Unpaired rows must not go through ``_score_node``: that path treats a
+        missing partner as implicit ``null`` children and can *match* gold
+        nulls. There is no partner row here, so every leaf is a one-sided miss.
+        """
+        if isinstance(value, Mapping):
+            props = schema_properties(schema)
+            keys = sorted(value.keys())
+            if len(keys) > 0:
+                for key in keys:
+                    child = f"{path}.{key}" if path else key
+                    self._count_subtree(child, value[key], props.get(key, {}), c, expected=expected)
+                return
+        if is_value_sequence(value) and any(isinstance(r, Mapping) for r in value):
+            subfield_names = array_subfield_names(schema, value)
+            item_sch = array_item_properties(schema)
             for i, row in enumerate(value):
-                rd = row if isinstance(row, dict) else {}
-                for s in subs:
+                rd = row if isinstance(row, Mapping) else {}
+                for s in subfield_names:
                     self._count_subtree(f"{path}[{i}].{s}", rd.get(s), item_sch.get(s, {}), c, expected=expected)
         elif expected:
             c.expected += 1
-            if self._ev_boxes.get(path):
-                c.g_expected += 1
+            self._note_grounded_expected(path, c)
             if self._ev_pages.get(path):
                 c.p_expected += 1
         else:
@@ -355,28 +429,44 @@ class _Scorer:
             # denominator (see _Counts.g_claims).
             c.predicted += 1
 
+    def _count_unmatched_nested(
+        self,
+        base: str,
+        row: Mapping[str, Any],
+        item_sch: Mapping[str, Any],
+        nested_names: Sequence[str],
+        c: _Counts,
+        *,
+        expected: bool,
+    ) -> None:
+        for s in nested_names:
+            self._count_subtree(f"{base}.{s}", row.get(s), item_sch.get(s, {}), c, expected=expected)
+
     def _score_array(
-        self, gt_field: str, pred_field: str, exp_rows: Any, act_rows: Any, schema: dict[str, Any], c: _Counts
+        self, gt_field: str, pred_field: str, exp_rows: Any, act_rows: Any, schema: Mapping[str, Any], c: _Counts
     ) -> None:
         # gt_field / pred_field are separate base paths: ground-truth cells (alt
         # values, evidence boxes) key off gt_field; predicted cells (citations)
         # key off pred_field. They differ once the outer array is reordered, so
         # threading both is what keeps nested grounding correct after a remap.
-        exp_rows = exp_rows if isinstance(exp_rows, list) else []
-        act_rows = act_rows if isinstance(act_rows, list) else []
-        subs = _array_subfields(schema if isinstance(schema, dict) else {}, exp_rows)
-        if not subs:
+        exp_rows = as_rows(exp_rows)
+        act_rows = as_rows(act_rows)
+        subfield_names = array_subfield_names(schema, exp_rows)
+        if len(subfield_names) == 0:
             return
-        item_sch = (schema or {}).get("items", {}).get("properties", {})
-        # A list-of-objects subfield is a real sub-record -> recurse (the depth
-        # array_record lacks). Scalars, scalar lists, and bare objects stay
-        # opaque cells, so a doc with no sub-record arrays scores bit-identically
-        # to array_record.
-        record_subs = [s for s in subs if _is_record_subfield(exp_rows, s)]
-        cell_subs = [s for s in subs if s not in record_subs]
+        item_sch = array_item_properties(schema)
+        # List-of-objects subfields recurse with another Hungarian pass.
+        # Dict-valued subfields recurse via ``_score_node`` (same as root).
+        # Scalars and scalar lists stay opaque cells.
+        object_array_names = [s for s in subfield_names if is_object_array_subfield(exp_rows, s)]
+        object_names = [
+            s for s in subfield_names if s not in object_array_names and is_object_subfield(exp_rows, act_rows, s)
+        ]
+        cell_names = [s for s in subfield_names if s not in object_array_names and s not in object_names]
         # Opaque-cell denominators: array_record-exact (rows x cell subfields).
-        c.expected += len(exp_rows) * len(cell_subs)
-        c.predicted += len(act_rows) * len(cell_subs)
+        # Object and object-array fields are counted by the recursion below.
+        c.expected += len(exp_rows) * len(cell_names)
+        c.predicted += len(act_rows) * len(cell_names)
         c.expected_rows += len(exp_rows)
         c.predicted_rows += len(act_rows)
         # A flat array whose full grounded matrix would be multi-GB: skip its
@@ -385,7 +475,7 @@ class _Scorer:
         # (value-identical for opaque cells), and not counting
         # g_expected/g_claims/p_expected/p_claims here keeps the grounded and
         # page denominators consistent with the skipped g_correct/p_correct.
-        # ``not record_subs`` guarantees no nested recursion, so the peel cannot
+        # ``not object_array_names and not object_names`` guarantees no nested recursion, so the peel cannot
         # shift nested TP. The memory win only lands on the plain peel path: an
         # array with genuine alternate values (``multi``) or field normalizers
         # still builds the full candidate matrix below regardless of ``giant`` --
@@ -393,11 +483,12 @@ class _Scorer:
         # threshold bounds the FULL matrix; the peel's residual matrix over
         # unmatched rows can still grow if few rows match exactly, so treat it as
         # a heuristic, not a hard ceiling.
-        giant = bool(
-            exp_rows
-            and act_rows
-            and cell_subs
-            and not record_subs
+        giant = (
+            len(exp_rows) > 0
+            and len(act_rows) > 0
+            and len(cell_names) > 0
+            and len(object_array_names) == 0
+            and len(object_names) == 0
             and len(exp_rows) * len(act_rows) > _GROUNDED_MAX_CELLS
         )
         # Page presence drives both the grounded-family denominators and the
@@ -412,16 +503,15 @@ class _Scorer:
             # document's grounded/page score incomplete and must be withheld
             # entirely. Pages are the superset, so this covers dropped bboxes too.
             dropped_grounding = any(
-                self._ev_pages.get(f"{gt_field}[{i}].{s}") for i in range(len(exp_rows)) for s in cell_subs
-            ) or any(self._pred_pages.get(f"{pred_field}[{j}].{s}") for j in range(len(act_rows)) for s in cell_subs)
+                self._ev_pages.get(f"{gt_field}[{i}].{s}") for i in range(len(exp_rows)) for s in cell_names
+            ) or any(self._pred_pages.get(f"{pred_field}[{j}].{s}") for j in range(len(act_rows)) for s in cell_names)
             if dropped_grounding:
                 c.grounded_incomplete = True
         else:
             for i in range(len(exp_rows)):
-                for s in cell_subs:
+                for s in cell_names:
                     gt_path = f"{gt_field}[{i}].{s}"
-                    if self._ev_boxes.get(gt_path):
-                        c.g_expected += 1
+                    self._note_grounded_expected(gt_path, c)
                     if self._ev_pages.get(gt_path):
                         c.p_expected += 1
                         has_ev_page = True
@@ -431,26 +521,29 @@ class _Scorer:
             # reflects ANY predicted page (the superset of any predicted bbox) so
             # the pairing-sensitive branch selection below covers both families.
             for j in range(len(act_rows)):
-                for s in cell_subs:
+                for s in cell_names:
                     if self._pred_pages.get(f"{pred_field}[{j}].{s}"):
                         has_pred_page = True
                         break
                 if has_pred_page:
                     break
-        # Sub-record subfields are counted by the recursion below, per matched
+        # Object-array subfields are counted by the recursion below, per matched
         # pair (and as one-sided misses for unmatched rows).
         match_for_exp: dict[int, int] = {}
-        if exp_rows and act_rows:
-            cost_subs = cell_subs or subs  # align on identity cells; fall back to all
+        if len(exp_rows) > 0 and len(act_rows) > 0:
+            # Align on opaque + object cells; objects still count as one cost cell.
+            cost_names: Sequence[str] = cell_names + object_names
+            if len(cost_names) == 0:
+                cost_names = subfield_names
             fuzzy = self._fuzzy
-            exp_dicts = [e if isinstance(e, dict) else {} for e in exp_rows]
+            exp_dicts = [e if isinstance(e, Mapping) else {} for e in exp_rows]
             # The alt index holds every leaf's evidence value, so most entries
             # equal the expected value. A genuinely different alternate expands
             # the zero-cost graph; in that case use full assignment semantics and
             # do not greedily peel canonical exact matches.
             multi = False
             for i, ed in enumerate(exp_dicts):
-                for s in cost_subs:
+                for s in cost_names:
                     canon = ed.get(s)
                     alt = self._alt.get(f"{gt_field}[{i}].{s}")
                     if alt:
@@ -469,16 +562,16 @@ class _Scorer:
             # carries normalizers at all (the default): the path scan is
             # O(rows x subfields) per array and would otherwise run for nothing.
             has_normalizer = (
-                bool(self._normalizers)
+                len(self._normalizers) > 0
                 and not multi
-                and any(self._normalizers.get(f"{gt_field}[{i}].{s}") for i in range(len(exp_rows)) for s in cost_subs)
+                and any(self._normalizers.get(f"{gt_field}[{i}].{s}") for i in range(len(exp_rows)) for s in cost_names)
             )
 
             if multi or has_normalizer:
                 exp_cands = []
                 for i, ed in enumerate(exp_dicts):
                     row_cands = []
-                    for s in cost_subs:
+                    for s in cost_names:
                         canon = ed.get(s)
                         alt = self._alt.get(f"{gt_field}[{i}].{s}")
                         cand = [canon]
@@ -488,39 +581,41 @@ class _Scorer:
                     exp_cands.append(row_cands)
                 cost = np.empty((len(act_rows), len(exp_rows)), dtype=np.int16)
                 for j, arow in enumerate(act_rows):
-                    ad = arow if isinstance(arow, dict) else {}
-                    avals = [ad.get(s) for s in cost_subs]
+                    ad = arow if isinstance(arow, Mapping) else {}
+                    avals = [ad.get(s) for s in cost_names]
                     for i, cands in enumerate(exp_cands):
                         cost[j, i] = sum(
                             not any(
                                 self._configured_cell_match(
-                                    f"{gt_field}[{i}].{cost_subs[si]}", cv, avals[si], cost_subs[si]
+                                    f"{gt_field}[{i}].{cost_names[si]}", cv, avals[si], cost_names[si]
                                 )
                                 for cv in cands[si]
                             )
-                            for si in range(len(cost_subs))
+                            for si in range(len(cost_names))
                         )
                 row_ind, col_ind = linear_sum_assignment(cost)
                 match_for_exp = {int(i): int(j) for j, i in zip(row_ind, col_ind, strict=True)}
-            elif record_subs or (has_ev_page and has_pred_page):
-                # Pairing-sensitive scoring: nested sub-records recurse on the
-                # matched predicted index, and per-cell grounding + page grading
-                # key off it too. Among equal-cost optima the exact-row peel could
+            elif len(object_array_names) > 0 or len(object_names) > 0 or (has_ev_page and has_pred_page):
+                # Pairing-sensitive scoring: nested object arrays and in-row objects
+                # recurse on the matched predicted index, and per-cell grounding +
+                # page grading key off it too. Among equal-cost optima the exact-row peel could
                 # pick a different pairing than the full assignment and shift
                 # grounded / page / nested TP, so fall back to full assignment to
                 # preserve the exact tie-break. ``has_ev_page``/``has_pred_page``
                 # are the bbox supersets, so this branch also covers every
                 # bbox-grounded array.
-                cost = _mismatch_cost_matrix(act_rows, exp_rows, cost_subs, fuzzy)
+                cost = mismatch_cost_matrix(act_rows, exp_rows, subfields=cost_names, fuzzy_field_thresholds=fuzzy)
                 row_ind, col_ind = linear_sum_assignment(cost)
                 match_for_exp = {int(i): int(j) for j, i in zip(row_ind, col_ind, strict=True)}
             else:
                 # Opaque-cell-only, un-grounded: the value score is pairing-
                 # independent (n_pairs*k - total_cost), so peeling exact rows is
                 # safe. Reuse the vectorized interned matrix on the residual rows.
-                assignment = _peel_exact_row_matches(act_rows, exp_rows, cost_subs, fuzzy)
+                assignment = peel_exact_row_matches(
+                    act_rows, exp_rows, subfields=cost_names, fuzzy_field_thresholds=fuzzy
+                )
                 match_for_exp = {int(i): int(j) for j, i in assignment.pairs}
-                if assignment.unmatched_actual_indices and assignment.unmatched_expected_indices:
+                if len(assignment.unmatched_actual_indices) > 0 and len(assignment.unmatched_expected_indices) > 0:
                     residual_actual = [act_rows[idx] for idx in assignment.unmatched_actual_indices]
                     residual_expected = [exp_rows[idx] for idx in assignment.unmatched_expected_indices]
                     # Memory ceiling on the residual assignment matrix (parallel to
@@ -535,7 +630,12 @@ class _Scorer:
                     if len(residual_actual) * len(residual_expected) > _GROUNDED_MAX_CELLS:
                         c.value_incomplete = True
                     else:
-                        cost = _mismatch_cost_matrix(residual_actual, residual_expected, cost_subs, fuzzy)
+                        cost = mismatch_cost_matrix(
+                            residual_actual,
+                            residual_expected,
+                            subfields=cost_names,
+                            fuzzy_field_thresholds=fuzzy,
+                        )
                         row_ind, col_ind = linear_sum_assignment(cost)
                         match_for_exp.update(
                             {
@@ -547,68 +647,90 @@ class _Scorer:
                         )
         matched_act = set(match_for_exp.values())
         for i, erow in enumerate(exp_rows):
-            ed = erow if isinstance(erow, dict) else {}
+            ed = erow if isinstance(erow, Mapping) else {}
             mj = match_for_exp.get(i)
             if mj is not None:
-                ad = act_rows[mj] if isinstance(act_rows[mj], dict) else {}
-                for s in cell_subs:
+                ad = act_rows[mj] if isinstance(act_rows[mj], Mapping) else {}
+                for s in cell_names:
                     gt_path = f"{gt_field}[{i}].{s}"
                     pred_path = f"{pred_field}[{mj}].{s}"
                     if not giant:
-                        if self._ev_boxes.get(gt_path) and self._pred_boxes.get(pred_path):
-                            c.g_claims += 1
+                        self._note_grounded_claim(gt_path, pred_path, c)
                         if self._ev_pages.get(gt_path) and self._pred_pages.get(pred_path):
                             c.p_claims += 1
                     self._score_cell(gt_path, pred_path, ed.get(s), ad.get(s), s, c, ground=not giant)
-                for s in record_subs:  # recurse with the matched predicted index, not the GT index
+                for s in object_array_names:  # recurse with the matched predicted index, not the GT index
                     self._score_array(
                         f"{gt_field}[{i}].{s}", f"{pred_field}[{mj}].{s}", ed.get(s), ad.get(s), item_sch.get(s, {}), c
                     )
-            else:  # unmatched GT row: cell subfields already counted; recurse sub-records as recall misses
-                for s in record_subs:
-                    self._count_subtree(f"{gt_field}[{i}].{s}", ed.get(s), item_sch.get(s, {}), c, expected=True)
-        for j, arow in enumerate(act_rows):  # extra predicted rows: sub-records are precision misses
+                for s in object_names:
+                    self._score_node(
+                        f"{gt_field}[{i}].{s}", f"{pred_field}[{mj}].{s}", ed.get(s), ad.get(s), item_sch.get(s, {}), c
+                    )
+            else:  # unmatched GT row: cell subfields already counted; recurse nested as recall misses
+                self._count_unmatched_nested(
+                    f"{gt_field}[{i}]", ed, item_sch, object_array_names + object_names, c, expected=True
+                )
+        for j, arow in enumerate(act_rows):  # extra predicted rows: nested fields are precision misses
             if j in matched_act:
                 continue
-            ad = arow if isinstance(arow, dict) else {}
-            for s in record_subs:
-                self._count_subtree(f"{pred_field}[{j}].{s}", ad.get(s), item_sch.get(s, {}), c, expected=False)
+            ad = arow if isinstance(arow, Mapping) else {}
+            self._count_unmatched_nested(
+                f"{pred_field}[{j}]", ad, item_sch, object_array_names + object_names, c, expected=False
+            )
 
-    def score_root(self, expected: dict[str, Any], actual: dict[str, Any], schema_props: dict[str, Any]) -> _Counts:
+    def _score_scalar_cell(self, gt_path: str, pred_path: str, ev: Any, av: Any, c: _Counts) -> None:
+        leaf = path_leaf(gt_path)
+        c.expected += 1
+        self._note_grounded_expected(gt_path, c)
+        self._note_grounded_claim(gt_path, pred_path, c)
+        if self._ev_pages.get(gt_path):
+            c.p_expected += 1
+            if self._pred_pages.get(pred_path):
+                c.p_claims += 1
+        self._score_cell(gt_path, pred_path, ev, av, leaf, c)
+        # An omitted key is an implicit null prediction and always enters the
+        # precision denominator, right or wrong -- exactly as if the model had
+        # asserted null explicitly.
+        c.predicted += 1
+
+    def _score_node(
+        self, gt_path: str, pred_path: str, ev: Any, av: Any, schema: Mapping[str, Any], c: _Counts
+    ) -> None:
+        if is_array_schema(schema, ev):
+            self._score_array(gt_path, pred_path, ev, av, schema, c)
+            return
+        ev_obj = isinstance(ev, Mapping)
+        av_obj = isinstance(av, Mapping)
+        if ev_obj or av_obj:
+            props = schema_properties(schema)
+            ed = ev if ev_obj else {}
+            ad = av if av_obj else {}
+            keys = sorted(set(ed) | set(ad))
+            if len(keys) == 0:
+                self._score_scalar_cell(gt_path, pred_path, ev, av, c)
+                return
+            for key in keys:
+                child_gt = f"{gt_path}.{key}" if gt_path else key
+                child_pred = f"{pred_path}.{key}" if pred_path else key
+                self._score_node(child_gt, child_pred, ed.get(key), ad.get(key), props.get(key, {}), c)
+            return
+        self._score_scalar_cell(gt_path, pred_path, ev, av, c)
+
+    def score_root(
+        self, expected: Mapping[str, Any], actual: Mapping[str, Any], schema_props: Mapping[str, Any]
+    ) -> _Counts:
         c = _Counts()
-        for field in sorted((set(expected) | set(actual)) - RESERVED_OUTPUT_KEYS):
-            fsch = schema_props.get(field, {})
-            ev = expected.get(field)
-            av = actual.get(field)
-            if _is_array_schema(fsch, ev):
-                self._score_array(field, field, ev, av, fsch, c)
-            else:
-                # Scalar or shallow-object cell, scored opaquely (array_record parity).
-                c.expected += 1
-                if self._ev_boxes.get(field):
-                    c.g_expected += 1
-                    if self._pred_boxes.get(field):
-                        c.g_claims += 1
-                if self._ev_pages.get(field):
-                    c.p_expected += 1
-                    if self._pred_pages.get(field):
-                        c.p_claims += 1
-                self._score_cell(field, field, ev, av, field, c)
-                # An omitted key is an implicit null prediction and always
-                # enters the precision denominator, right or wrong -- exactly as
-                # if the model had asserted null explicitly. Counting it only
-                # when correct would let tp exceed predicted (precision > 1.0),
-                # and counting it never would make omitting an uncertain field
-                # strictly outscore asserting it.
-                c.predicted += 1
+        for name in sorted((set(expected) | set(actual)) - RESERVED_OUTPUT_KEYS):
+            self._score_node(name, name, expected.get(name), actual.get(name), schema_props.get(name, {}), c)
         return c
 
 
-def _build_rule_indexes(
+def build_rule_indexes(
     field_rules: list[ExtractFieldTestRule],
 ) -> tuple[
     dict[str, list[Any]],
-    dict[str, list[tuple[int, list[float]]]],
+    BoxIndex,
     dict[str, set[int]],
     dict[str, tuple[str, ...]],
 ]:
@@ -619,7 +741,7 @@ def _build_rule_indexes(
     annotation still makes a cell page-gradeable.
     """
     alt: dict[str, list[Any]] = {}
-    boxes: dict[str, list[tuple[int, list[float]]]] = {}
+    boxes: BoxIndex = {}
     pages: dict[str, set[int]] = {}
     normalizers: dict[str, tuple[str, ...]] = {}
     for rule in field_rules:
@@ -633,21 +755,22 @@ def _build_rule_indexes(
         for e in entries:
             if e.page is not None:
                 pages.setdefault(path, set()).add(int(e.page))
-                if e.bbox is not None and len(e.bbox) >= 4:
-                    boxes.setdefault(path, []).append((int(e.page), [float(x) for x in e.bbox[:4]]))
+                parsed = _validated_bbox(e.bbox) if e.bbox is not None else None
+                if parsed is not None:
+                    boxes.setdefault(path, []).append((int(e.page), parsed))
     return alt, boxes, pages, normalizers
 
 
-def _index_citations(
+def index_citations(
     field_citations: list[Any],
-) -> tuple[dict[str, list[tuple[int, list[float]]]], dict[str, set[int]]]:
+) -> tuple[BoxIndex, dict[str, set[int]]]:
     """field_path -> citation boxes; field_path -> citation pages.
 
     A page-only citation (page present, bbox missing) is indexed for pages but
     not for boxes, so it can satisfy a page match without ever being credited as
     a bbox match.
     """
-    boxes: dict[str, list[tuple[int, list[float]]]] = {}
+    boxes: BoxIndex = {}
     pages: dict[str, set[int]] = {}
     for cit in field_citations or []:
         path = cit.get("field_path") if isinstance(cit, dict) else getattr(cit, "field_path", None)
@@ -656,8 +779,9 @@ def _index_citations(
         if not path or page is None:
             continue
         pages.setdefault(path, set()).add(int(page))
-        if bbox and len(bbox) >= 4:
-            boxes.setdefault(path, []).append((int(page), [float(x) for x in bbox[:4]]))
+        parsed = _validated_bbox(bbox) if isinstance(bbox, (list, tuple)) else None
+        if parsed is not None:
+            boxes.setdefault(path, []).append((int(page), parsed))
     return boxes, pages
 
 
@@ -675,7 +799,7 @@ def compute_unified_evidence_metrics(
     field_citations: list[Any] | None = None,
     data_schema: dict[str, Any] | None = None,
     *,
-    fuzzy_field_thresholds: dict[str, float] | None = None,
+    fuzzy_field_thresholds: Mapping[str, float] | None = None,
     normalize_dates: bool = True,
     bbox_iou_threshold: float = 0.5,
 ) -> list[MetricValue]:
@@ -684,24 +808,33 @@ def compute_unified_evidence_metrics(
     Returns an empty list when either side is not a dict (no array structure to
     score), matching ``array_record``'s ``counts is None`` guard.
     """
-    expected = _unwrap_value(expected_output)
-    actual = _unwrap_value(extracted_data)
-    if not isinstance(expected, dict) or not isinstance(actual, dict):
+    expected = unwrap_value(expected_output)
+    actual = unwrap_value(extracted_data)
+    if not isinstance(expected, Mapping) or not isinstance(actual, Mapping):
         return []
     if normalize_dates:
-        expected = _normalize_dates_deep(expected)
-        actual = _normalize_dates_deep(actual)
+        expected = normalize_dates_deep(expected)
+        actual = normalize_dates_deep(actual)
 
     fuzzy = dict(DEFAULT_FUZZY_FIELD_THRESHOLDS if fuzzy_field_thresholds is None else fuzzy_field_thresholds)
-    alt, ev_boxes, ev_pages, normalizers = _build_rule_indexes(field_rules)
+    alt, ev_boxes, ev_pages, normalizers = build_rule_indexes(field_rules)
     if normalize_dates:
-        alt = {p: _normalize_dates_deep(v) for p, v in alt.items()}
-    pred_boxes, pred_pages = _index_citations(field_citations or [])
-    schema_props = (data_schema or {}).get("properties", {})
+        alt = {p: normalize_dates_deep(v) for p, v in alt.items()}
+    pred_boxes, pred_pages = index_citations(field_citations or [])
+    # Same inliner extract GT lint uses: root ``#/$defs/X`` (and ``definitions``).
+    resolved = resolve_refs(data_schema) if isinstance(data_schema, Mapping) else {}
+    schema_props = schema_properties(resolved)
 
-    c = _Scorer(alt, ev_boxes, ev_pages, normalizers, pred_boxes, pred_pages, fuzzy, bbox_iou_threshold).score_root(
-        expected, actual, schema_props
-    )
+    c = Scorer(
+        alt_values=alt,
+        evidence_boxes=ev_boxes,
+        evidence_pages=ev_pages,
+        normalizers=normalizers,
+        pred_boxes=pred_boxes,
+        pred_pages=pred_pages,
+        fuzzy=fuzzy,
+        iou_threshold=bbox_iou_threshold,
+    ).score_root(expected, actual, schema_props)
     if c.expected == 0 and c.predicted == 0:
         return []
 

--- a/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
@@ -92,6 +92,7 @@ from extract_bench.evaluation.metrics.extract.array_record_match_metric import (
 from extract_bench.evaluation.metrics.extract.json_subset_match import normalize_date_string
 from extract_bench.inference.providers.extract.table_codegen.schema_utils import (
     resolve_refs,
+    schema_items,
     schema_properties,
 )
 from extract_bench.schemas.evaluation import MetricValue
@@ -276,18 +277,47 @@ def path_leaf(path: str) -> str:
     return path.rsplit(".", 1)[-1].split("[", 1)[0]
 
 
-def is_object_array_subfield(rows: Sequence[Any], sub: str) -> bool:
-    """True when ``sub`` is a list of objects on any row (nested Hungarian).
+def is_object_array_schema(field_schema: Any) -> bool:
+    """True when JSON Schema describes an array of objects (incl. combinators)."""
+    if not isinstance(field_schema, Mapping):
+        return False
+    if len(array_item_properties(field_schema)) > 0:
+        return True
+    items = schema_items(field_schema)
+    if not isinstance(items, Mapping):
+        return False
+    raw = items.get("type")
+    types = raw if isinstance(raw, list) else [raw]
+    return "object" in types
 
-    Distinct from ``is_object_subfield`` (a single dict on the row). Scalar
-    lists stay opaque cells.
-    """
+
+def _row_has_object_list(rows: Sequence[Any], sub: str) -> bool:
     for row in rows:
         if isinstance(row, Mapping):
             value = row.get(sub)
             if is_value_sequence(value) and len(value) > 0 and isinstance(value[0], Mapping):
                 return True
     return False
+
+
+def is_object_array_subfield(
+    rows: Sequence[Any],
+    sub: str,
+    extra_rows: Sequence[Any] | None = None,
+    field_schema: Any = None,
+) -> bool:
+    """True when ``sub`` is a nested object-array (Hungarian at the next depth).
+
+    Distinct from ``is_object_subfield`` (a single dict on the row). Scalar
+    lists stay opaque cells. Empty or null gold still counts when the item
+    schema is an object or the prediction already holds a list of objects —
+    otherwise invented rows collapse to one opaque miss.
+    """
+    if is_object_array_schema(field_schema):
+        return True
+    if _row_has_object_list(rows, sub):
+        return True
+    return extra_rows is not None and _row_has_object_list(extra_rows, sub)
 
 
 def is_object_subfield(exp_rows: Sequence[Any], act_rows: Sequence[Any], sub: str) -> bool:
@@ -458,7 +488,11 @@ class Scorer:
         # List-of-objects subfields recurse with another Hungarian pass.
         # Dict-valued subfields recurse via ``_score_node`` (same as root).
         # Scalars and scalar lists stay opaque cells.
-        object_array_names = [s for s in subfield_names if is_object_array_subfield(exp_rows, s)]
+        object_array_names = [
+            s
+            for s in subfield_names
+            if is_object_array_subfield(exp_rows, s, extra_rows=act_rows, field_schema=item_sch.get(s, {}))
+        ]
         object_names = [
             s for s in subfield_names if s not in object_array_names and is_object_subfield(exp_rows, act_rows, s)
         ]

--- a/src/extract_bench/inference/providers/extract/table_codegen/schema_utils.py
+++ b/src/extract_bench/inference/providers/extract/table_codegen/schema_utils.py
@@ -123,6 +123,44 @@ def resolve_refs(schema: Any, root: dict[str, Any] | None = None, _seen: frozens
     return schema
 
 
+def schema_properties(schema: Any) -> dict[str, Any]:
+    """Merge ``properties`` from this node and nested ``anyOf`` / ``oneOf`` / ``allOf``.
+
+    Used for object-shaped fields whose schema is written as
+    ``anyOf: [{$ref: ...}, {type: null}]`` after ``resolve_refs`` has inlined
+    the ref. Later combinator branches overwrite earlier keys of the same name.
+    ``$ref`` is not followed here.
+    """
+    if not isinstance(schema, dict):
+        return {}
+    props: dict[str, Any] = dict(schema.get("properties") or {}) if "properties" in schema else {}
+    for key in ("anyOf", "oneOf", "allOf"):
+        for alt in schema.get(key) or []:
+            props.update(schema_properties(alt))
+    return props
+
+
+def schema_items(schema: Any) -> dict[str, Any]:
+    """The array ``items`` schema, looking through ``anyOf`` / ``oneOf`` / ``allOf``.
+
+    Prefer a top-level ``items`` dict (a bare ``{type: array, items: ...}``
+    node). Otherwise return the first combinator alternative that has one.
+    The result is still the items *node* (often an object schema); flatten its
+    fields with ``schema_properties``. Does not follow ``$ref``.
+    """
+    if not isinstance(schema, dict):
+        return {}
+    items = schema.get("items")
+    if isinstance(items, dict):
+        return items
+    for key in ("anyOf", "oneOf", "allOf"):
+        for alt in schema.get(key) or []:
+            found = schema_items(alt)
+            if found:
+                return found
+    return {}
+
+
 def _typestr(s: dict[str, Any]) -> str:
     s = _effective(s)
     t = s.get("type")

--- a/tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py
@@ -1,13 +1,329 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
+from pathlib import Path
 
+import pytest
+
+from extract_bench.evaluation.evaluators.extract import ExtractEvaluator
 from extract_bench.evaluation.metrics.extract.array_record_match_metric import (
     _UNHASHABLE,
+    DEFAULT_FUZZY_FIELD_THRESHOLDS,
+    ArrayRecordMatchMetric,
     _cell_key,
     _intern_field,
-    _mismatch_cost_matrix,
+    array_item_properties,
+    array_subfield_names,
+    cell_match,
+    compute_array_record_match_counts,
+    is_array_schema,
+    mismatch_cost_matrix,
 )
+from extract_bench.schemas.extract_output import ExtractOutput
+from extract_bench.schemas.pipeline_io import InferenceRequest, InferenceResult
+from extract_bench.schemas.product import ProductType
+from extract_bench.test_cases.schema import ExtractTestCase
+
+
+def _schema() -> dict:
+    return {
+        "type": "object",
+        "properties": {
+            "account": {"type": ["string", "null"]},
+            "transactions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "date": {"type": ["string", "null"]},
+                        "description": {"type": ["string", "null"]},
+                        "amount": {"type": "object"},
+                    },
+                },
+            },
+        },
+    }
+
+
+def _expected() -> dict:
+    return {
+        "account": "1234",
+        "transactions": [
+            {"date": "2026-01-01", "description": "Coffee Shop", "amount": {"amount": 4.5, "currency": "USD"}},
+            {"date": "2026-01-02", "description": "Grocery Store", "amount": {"amount": 21.0, "currency": "USD"}},
+        ],
+    }
+
+
+def _metric_by_name(actual: dict) -> dict[str, float]:
+    values = ArrayRecordMatchMetric().compute(expected=_expected(), actual=actual, data_schema=_schema())
+    return {metric.metric_name: metric.value for metric in values}
+
+
+def test_array_subfield_names_reads_items_through_anyof() -> None:
+    wrapped = {
+        "anyOf": [
+            {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "sku": {"type": "string"},
+                        "qty": {"type": "integer"},
+                    },
+                },
+            },
+            {"type": "null"},
+        ]
+    }
+    assert array_item_properties(wrapped) == {
+        "sku": {"type": "string"},
+        "qty": {"type": "integer"},
+    }
+    assert array_subfield_names(wrapped, []) == ["sku", "qty"]
+
+
+def test_string_gold_is_not_treated_as_an_array() -> None:
+    assert is_array_schema({}, "not-an-array") is False
+    assert is_array_schema({"type": "string"}, "not-an-array") is False
+    assert is_array_schema({}, ["not-an-array"]) is True
+
+
+def test_array_record_match_is_order_insensitive() -> None:
+    actual = {
+        "account": "1234",
+        "transactions": list(reversed(_expected()["transactions"])),
+    }
+
+    metrics = _metric_by_name(actual)
+
+    assert metrics["array_record_accuracy"] == 1.0
+    assert metrics["array_record_precision"] == 1.0
+    assert metrics["array_record_f1"] == 1.0
+
+
+def test_array_record_exact_peel_handles_large_shifted_array() -> None:
+    rows = [{"id": str(i), "value": f"value-{i}"} for i in range(30_000)]
+    expected = {"rows": rows}
+    actual = {"rows": [{"id": "extra", "value": "extra"}, *rows]}
+    schema = {
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": ["string", "null"]},
+                        "value": {"type": ["string", "null"]},
+                    },
+                },
+            }
+        },
+    }
+
+    counts = compute_array_record_match_counts(expected=expected, actual=actual, data_schema=schema)
+
+    assert counts is not None
+    assert counts.correct == 60_000
+    assert counts.expected_total == 60_000
+    assert counts.predicted_total == 60_002
+
+
+def test_array_record_accuracy_matches_extend_recall_denominator_for_extra_rows() -> None:
+    actual = {
+        "account": "1234",
+        "transactions": [
+            *_expected()["transactions"],
+            {"date": "2026-01-03", "description": "Extra Row", "amount": {"amount": 99.0, "currency": "USD"}},
+        ],
+    }
+
+    metrics = _metric_by_name(actual)
+
+    assert metrics["array_record_accuracy"] == 1.0
+    assert metrics["array_record_precision"] == pytest.approx(7 / 10)
+    assert metrics["array_record_f1"] < 1.0
+    assert metrics["array_record_row_count_ratio"] == 1.5
+
+
+def test_array_record_ignores_reserved_provenance_key() -> None:
+    # A reserved _provenance key (top-level object AND each array record) is source-
+    # attribution metadata, never an extracted cell — it must not change any value
+    # count, so a perfect prediction carrying it still scores 1.0.
+    exp = _expected()
+    perfect_with_prov = {
+        **exp,
+        "_provenance": {"page": 1},
+        "transactions": [{**r, "_provenance": {"page": 2}} for r in exp["transactions"]],
+    }
+    metrics = _metric_by_name(perfect_with_prov)
+    assert metrics["array_record_accuracy"] == 1.0
+    assert metrics["array_record_precision"] == 1.0
+    assert metrics["array_record_recall"] == 1.0
+    assert metrics["array_record_f1"] == 1.0
+
+
+def test_array_record_match_penalizes_missing_rows() -> None:
+    actual = {
+        "account": "1234",
+        "transactions": [_expected()["transactions"][0]],
+    }
+
+    metrics = _metric_by_name(actual)
+
+    assert metrics["array_record_accuracy"] == pytest.approx(4 / 7)
+    assert metrics["array_record_recall"] == pytest.approx(4 / 7)
+    assert metrics["array_record_precision"] == 1.0
+
+
+def test_array_record_match_applies_configured_fuzzy_fields() -> None:
+    actual = {
+        "account": "1234",
+        "transactions": [
+            {"date": "2026-01-01", "description": "Coffee-Shop", "amount": {"amount": 4.5, "currency": "USD"}},
+            {"date": "2026-01-02", "description": "Grocery Store", "amount": {"amount": 21.0, "currency": "USD"}},
+        ],
+    }
+
+    metrics = _metric_by_name(actual)
+
+    assert metrics["array_record_accuracy"] == 1.0
+
+
+def test_array_record_fuzzy_fields_use_full_assignment() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {"type": "object", "properties": {"court": {"type": ["string", "null"]}}},
+            }
+        },
+    }
+    expected = {"rows": [{"court": "apple"}, {"court": "apples"}]}
+    actual = {"rows": [{"court": "apple"}, {"court": "applez"}]}
+
+    counts = compute_array_record_match_counts(expected=expected, actual=actual, data_schema=schema)
+
+    assert counts is not None
+    assert counts.correct == 2
+    assert counts.expected_total == 2
+
+
+def test_array_record_match_normalizes_dates() -> None:
+    """Differing date formats for the same date must count as a match,
+    aligned with json_subset_match's normalize_dates behavior."""
+    actual = {
+        "account": "1234",
+        "transactions": [
+            {"date": "Jan 1, 2026", "description": "Coffee Shop", "amount": {"amount": 4.5, "currency": "USD"}},
+            {"date": "01/02/2026", "description": "Grocery Store", "amount": {"amount": 21.0, "currency": "USD"}},
+        ],
+    }
+
+    metrics = _metric_by_name(actual)
+
+    assert metrics["array_record_accuracy"] == 1.0
+    assert metrics["array_record_precision"] == 1.0
+
+
+def test_array_record_match_keeps_punctuation_spacing_significant_by_default() -> None:
+    # The default cell equality is shared by every extract dataset, so
+    # whitespace around punctuation stays significant here. Datasets that want
+    # this leniency opt in per field via the 'punctuation_spacing' normalizer
+    # (unified evidence metric).
+    fuzzy = DEFAULT_FUZZY_FIELD_THRESHOLDS
+
+    assert not cell_match("R. L. Underwood", "R.L.Underwood", "operator", fuzzy_field_thresholds=fuzzy)
+    assert not cell_match("P.O. Box 978", "P.O.Box 978", "address", fuzzy_field_thresholds=fuzzy)
+    assert not cell_match("Total Depth", "TotalDepth", "field", fuzzy_field_thresholds=fuzzy)
+    assert not cell_match("1,000", "1000", "amount", fuzzy_field_thresholds=fuzzy)
+    assert cell_match("R. L.\nUnderwood", "R. L. Underwood", "operator", fuzzy_field_thresholds=fuzzy)
+
+
+def test_array_record_match_date_normalization_can_be_disabled() -> None:
+    actual = {
+        "account": "1234",
+        "transactions": [
+            {"date": "Jan 1, 2026", "description": "Coffee Shop", "amount": {"amount": 4.5, "currency": "USD"}},
+            {"date": "2026-01-02", "description": "Grocery Store", "amount": {"amount": 21.0, "currency": "USD"}},
+        ],
+    }
+
+    counts = compute_array_record_match_counts(
+        expected=_expected(),
+        actual=actual,
+        data_schema=_schema(),
+        normalize_dates=False,
+    )
+
+    assert counts is not None
+    # The "Jan 1, 2026" cell no longer matches GT "2026-01-01" when
+    # normalization is off; everything else still matches.
+    assert counts.correct == counts.expected_total - 1
+
+
+def test_array_record_match_does_not_normalize_id_like_strings() -> None:
+    """Pure digit strings (account numbers, IDs) must pass through date
+    normalization untouched and still compare exactly."""
+    counts = compute_array_record_match_counts(
+        expected=_expected(),
+        actual=_expected(),
+        data_schema=_schema(),
+    )
+
+    assert counts is not None
+    assert counts.correct == counts.expected_total
+
+
+def test_array_record_match_returns_none_when_no_top_level_array_records() -> None:
+    counts = compute_array_record_match_counts(
+        expected={"account": "1234"},
+        actual={"account": "1234"},
+        data_schema={"type": "object", "properties": {"account": {"type": "string"}}},
+    )
+
+    assert counts is None
+
+
+def test_extract_evaluator_emits_array_record_metrics() -> None:
+    test_case = ExtractTestCase(
+        test_id="longarray/example",
+        group="longarray",
+        file_path=Path("example.pdf"),
+        data_schema=_schema(),
+        expected_output=_expected(),
+    )
+    inference_result = InferenceResult(
+        request=InferenceRequest(
+            example_id="example",
+            source_file_path="example.pdf",
+            product_type=ProductType.EXTRACT,
+        ),
+        pipeline_name="candidate",
+        product_type=ProductType.EXTRACT,
+        raw_output={},
+        output=ExtractOutput(
+            example_id="example",
+            pipeline_name="candidate",
+            extracted_data={
+                "account": "1234",
+                "transactions": list(reversed(_expected()["transactions"])),
+            },
+        ),
+        started_at=datetime.now(),
+        completed_at=datetime.now(),
+        latency_in_ms=1,
+    )
+
+    result = ExtractEvaluator().evaluate(inference_result, test_case)
+    metrics = {metric.metric_name: metric.value for metric in result.metrics}
+
+    # Both metrics are order-invariant: reversed-but-correct rows score 1.0.
+    assert metrics["accuracy"] == 1.0
+    assert metrics["array_record_accuracy"] == 1.0
 
 
 def _jsonable_intern_key(key: object) -> object:
@@ -42,7 +358,7 @@ def test_intern_field_list_column_matches_pairwise_mismatch_cost() -> None:
     expected = [{"addr": ["c"]}, {"addr": ["a", "b"]}]
     interned = _intern_field(actual, expected, "addr")
     assert interned is not None
-    cost = _mismatch_cost_matrix(actual, expected, ["addr"], {})
+    cost = mismatch_cost_matrix(actual, expected, subfields=["addr"], fuzzy_field_thresholds={})
     assert cost[0, 1] == 0
     assert cost[1, 0] == 0
     assert cost[0, 0] == 1
@@ -54,8 +370,30 @@ def test_intern_field_dict_column_matches_pairwise_mismatch_cost() -> None:
     expected = [{"amount": {"currency": "EUR", "amount": 1.0}}, {"amount": {"currency": "USD", "amount": 4.5}}]
     interned = _intern_field(actual, expected, "amount")
     assert interned is not None
-    cost = _mismatch_cost_matrix(actual, expected, ["amount"], {})
+    cost = mismatch_cost_matrix(actual, expected, subfields=["amount"], fuzzy_field_thresholds={})
     assert cost[0, 1] == 0
     assert cost[1, 0] == 0
     assert cost[0, 0] == 1
     assert cost[1, 1] == 1
+
+
+def test_array_record_precision_stays_bounded_when_null_scalars_are_omitted() -> None:
+    """An omitted GT-null scalar matches as an implicit null, so it must also
+    count as a prediction -- otherwise correct exceeds predicted_total and
+    precision runs past 1.0 (omission would outscore an explicit null)."""
+    schema = _schema()
+    for name in ("note_a", "note_b", "note_c"):
+        schema["properties"][name] = {"type": ["string", "null"]}
+    expected = {**_expected(), "note_a": None, "note_b": None, "note_c": None}
+    # Model omits the null scalars entirely and gets the account wrong.
+    actual = {"account": "9999", "transactions": _expected()["transactions"]}
+
+    counts = compute_array_record_match_counts(
+        expected=expected, actual=actual, data_schema=schema, fuzzy_field_thresholds=None
+    )
+
+    assert counts is not None
+    assert counts.predicted_total >= counts.correct
+    # 4 scalars (account wrong, 3 implicit nulls correct) + 6 array cells.
+    assert counts.predicted_total == 10
+    assert counts.correct == 9

--- a/tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py
@@ -85,6 +85,35 @@ def test_array_subfield_names_reads_items_through_anyof() -> None:
     assert is_array_schema(wrapped) is True
 
 
+def test_array_record_scores_ref_item_schema() -> None:
+    """``items: {$ref: #/$defs/...}`` must still expand columns (same inliner as unified)."""
+    schema = {
+        "type": "object",
+        "$defs": {
+            "Line": {
+                "type": "object",
+                "properties": {
+                    "sku": {"type": "string"},
+                    "qty": {"type": "integer"},
+                },
+            }
+        },
+        "properties": {
+            "lines": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/Line"},
+            }
+        },
+    }
+    expected = {"lines": [{"sku": "A", "qty": 1}, {"sku": "B", "qty": 2}]}
+    actual = {"lines": [{"sku": "B", "qty": 2}, {"sku": "A", "qty": 1}]}
+    counts = compute_array_record_match_counts(expected=expected, actual=actual, data_schema=schema)
+    assert counts is not None
+    assert counts.correct == 4
+    assert counts.expected_total == 4
+    assert counts.predicted_total == 4
+
+
 def test_is_array_schema_ignores_gold_and_reads_combinators() -> None:
     assert is_array_schema({}) is False
     assert is_array_schema({"type": "string"}) is False

--- a/tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py
@@ -81,13 +81,16 @@ def test_array_subfield_names_reads_items_through_anyof() -> None:
         "sku": {"type": "string"},
         "qty": {"type": "integer"},
     }
-    assert array_subfield_names(wrapped, []) == ["sku", "qty"]
+    assert array_subfield_names(wrapped) == ["sku", "qty"]
+    assert is_array_schema(wrapped) is True
 
 
-def test_string_gold_is_not_treated_as_an_array() -> None:
-    assert is_array_schema({}, "not-an-array") is False
-    assert is_array_schema({"type": "string"}, "not-an-array") is False
-    assert is_array_schema({}, ["not-an-array"]) is True
+def test_is_array_schema_ignores_gold_and_reads_combinators() -> None:
+    assert is_array_schema({}) is False
+    assert is_array_schema({"type": "string"}) is False
+    assert is_array_schema({"type": "array"}) is True
+    # A list in gold does not make an untyped/string field an array.
+    assert is_array_schema({}) is False
 
 
 def test_array_record_match_is_order_insensitive() -> None:

--- a/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
@@ -429,6 +429,56 @@ def test_object_array_subfield_gets_per_child_credit() -> None:
     assert _val(uni, "extract_unified_value_recall") > _val(arr, "array_record_recall")
 
 
+def test_empty_gt_object_array_expands_predicted_children() -> None:
+    """Empty (or null) gold object-array still expands invented predicted rows.
+
+    Schema says ``equipment_adjustments`` is an array of objects. Gold is ``[]``;
+    the prediction invents two rows / four child values. Those must be four
+    precision misses, not one opaque cell.
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "vehicles": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "year": {"type": ["string", "null"]},
+                        "equipment_adjustments": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {"type": ["string", "null"]},
+                                    "amount": {"type": ["number", "null"]},
+                                },
+                            },
+                        },
+                    },
+                },
+            }
+        },
+    }
+    expected_empty = {"vehicles": [{"year": "2020", "equipment_adjustments": []}]}
+    expected_null = {"vehicles": [{"year": "2020", "equipment_adjustments": None}]}
+    actual = {
+        "vehicles": [
+            {
+                "year": "2020",
+                "equipment_adjustments": [
+                    {"name": "A", "amount": 1},
+                    {"name": "B", "amount": 2},
+                ],
+            }
+        ]
+    }
+    for expected in (expected_empty, expected_null):
+        uni = compute_unified_evidence_metrics(expected, actual, [], [], schema)
+        assert _val(uni, "extract_unified_value_recall") == 1.0
+        assert _val(uni, "extract_unified_value_precision") == 0.2
+
+
 def test_object_wrapping_array_of_records_with_nested_object_arrays() -> None:
     """Root object → child object → array of records → nested object-array.
 

--- a/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
@@ -9,9 +9,20 @@ from extract_bench.evaluation.metrics.extract.array_record_match_metric import (
     ArrayRecordMatchMetric,
 )
 from extract_bench.evaluation.metrics.extract.unified_evidence_metric import (
+    build_rule_indexes,
     compute_unified_evidence_metrics,
+    index_citations,
+    iou_xywh,
+    path_leaf,
 )
 from extract_bench.test_cases.schema import ExtractFieldTestRule, FieldEvidence
+
+
+def test_path_leaf_strips_parent_and_trailing_index() -> None:
+    assert path_leaf("account") == "account"
+    assert path_leaf("holdings[0].security") == "security"
+    assert path_leaf("entities[0].aliases[1].name") == "name"
+    assert path_leaf("rows[2]") == "rows"
 
 
 def _schema() -> dict[str, Any]:
@@ -271,9 +282,110 @@ def test_over_extraction_lowers_precision() -> None:
     assert _val(uni, "extract_unified_value_precision") < 1.0  # extra row penalized
 
 
-# ----------------------------------------------------- nested sub-records
-def test_object_array_subfield_gets_per_record_credit() -> None:
-    # `tags` is a list-of-objects sub-record. array_record scores it as one
+def test_bare_object_recurses_to_child_cells() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "vendor": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "city": {"type": ["string", "null"]},
+                },
+            }
+        },
+    }
+    expected = {"vendor": {"name": "Acme", "city": "Austin"}}
+    actual = {"vendor": {"name": "Acme", "city": "Dallas"}}
+    rules = [_rule("vendor.name", "Acme"), _rule("vendor.city", "Austin")]
+    uni = compute_unified_evidence_metrics(expected, actual, rules, [], schema)
+    # Two cells, one miss: recall 0.5, precision 0.5 (not one opaque 0).
+    assert _val(uni, "extract_unified_value_recall") == 0.5
+    assert _val(uni, "extract_unified_value_precision") == 0.5
+
+
+def test_omitted_object_is_null_children_not_one_miss() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "vendor": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": ["string", "null"]},
+                            "city": {"type": ["string", "null"]},
+                        },
+                    },
+                    {"type": "null"},
+                ]
+            }
+        },
+    }
+    expected = {"vendor": {"name": "Acme", "city": "Austin"}}
+    actual: dict[str, Any] = {}
+    rules = [_rule("vendor.name", "Acme"), _rule("vendor.city", "Austin")]
+    uni = compute_unified_evidence_metrics(expected, actual, rules, [], schema)
+    assert _val(uni, "extract_unified_value_recall") == 0.0
+    assert _val(uni, "extract_unified_value_precision") == 0.0
+    # Two implicit-null children (root ``.get``), not one opaque cell.
+    assert _val(uni, "extract_unified_value_recall") == _val(uni, "extract_unified_value_precision")
+
+
+def test_null_object_matches_omitted_and_explicit_null() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": ["object", "null"]}},
+    }
+    expected = {"vendor": None}
+    rules = [_rule("vendor", None)]
+    omitted = compute_unified_evidence_metrics(expected, {}, rules, [], schema)
+    explicit = compute_unified_evidence_metrics(expected, {"vendor": None}, rules, [], schema)
+    assert _val(omitted, "extract_unified_value_f1") == 1.0
+    assert _val(explicit, "extract_unified_value_f1") == 1.0
+
+
+def test_object_inside_array_row_recurses_to_child_cells() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": ["string", "null"]},
+                        "addr": {
+                            "type": "object",
+                            "properties": {
+                                "city": {"type": ["string", "null"]},
+                                "zip": {"type": ["string", "null"]},
+                            },
+                        },
+                    },
+                },
+            }
+        },
+    }
+    expected = {"rows": [{"id": "1", "addr": {"city": "A", "zip": "1"}}]}
+    actual = {"rows": [{"id": "1", "addr": {"city": "A", "zip": "2"}}]}
+    rules = [
+        _rule("rows[0].id", "1"),
+        _rule("rows[0].addr.city", "A"),
+        _rule("rows[0].addr.zip", "1"),
+    ]
+    uni = compute_unified_evidence_metrics(expected, actual, rules, [], schema)
+    arr = ArrayRecordMatchMetric().compute(expected=expected, actual=actual, data_schema=schema)
+    # id + city match, zip misses: 2/3. array_record still treats addr as one cell (1/2).
+    assert _val(uni, "extract_unified_value_recall") == 2 / 3
+    assert _val(uni, "extract_unified_value_precision") == 2 / 3
+    assert _val(arr, "array_record_recall") == 0.5
+    assert _val(uni, "extract_unified_value_recall") > _val(arr, "array_record_recall")
+
+
+# ----------------------------------------------------- nested object arrays
+def test_object_array_subfield_gets_per_child_credit() -> None:
+    # `tags` is a list of objects. array_record scores it as one
     # opaque cell (whole list mismatches -> 1 of 2 subfields correct -> 0.5);
     # the unified metric recurses, so only tags[1].name is wrong -> 4 of 5
     # cells -> 0.8. This is the depth array_record cannot give.
@@ -317,6 +429,153 @@ def test_object_array_subfield_gets_per_record_credit() -> None:
     assert _val(uni, "extract_unified_value_recall") > _val(arr, "array_record_recall")
 
 
+def test_object_wrapping_array_of_records_with_nested_object_arrays() -> None:
+    """Root object → child object → array of records → nested object-array.
+
+    Inner service rows are reordered; Hungarian at that depth still pairs them.
+    One paid miss: 6 leaves, 5 correct.
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "packet": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": ["string", "null"]},
+                    "claims": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "claim_id": {"type": ["string", "null"]},
+                                "services": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "code": {"type": ["string", "null"]},
+                                            "paid": {"type": ["number", "null"]},
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            }
+        },
+    }
+    expected = {
+        "packet": {
+            "title": "EOB",
+            "claims": [
+                {
+                    "claim_id": "C1",
+                    "services": [{"code": "A", "paid": 1.0}, {"code": "B", "paid": 2.0}],
+                }
+            ],
+        }
+    }
+    actual = {
+        "packet": {
+            "title": "EOB",
+            "claims": [
+                {
+                    "claim_id": "C1",
+                    "services": [{"code": "B", "paid": 2.0}, {"code": "A", "paid": 9.0}],
+                }
+            ],
+        }
+    }
+    rules = [
+        _rule("packet.title", "EOB"),
+        _rule("packet.claims[0].claim_id", "C1"),
+        _rule("packet.claims[0].services[0].code", "A"),
+        _rule("packet.claims[0].services[0].paid", 1.0),
+        _rule("packet.claims[0].services[1].code", "B"),
+        _rule("packet.claims[0].services[1].paid", 2.0),
+    ]
+    uni = compute_unified_evidence_metrics(expected, actual, rules, [], schema)
+    arr = ArrayRecordMatchMetric().compute(expected=expected, actual=actual, data_schema=schema)
+    assert _val(uni, "extract_unified_value_recall") == 5 / 6
+    assert _val(uni, "extract_unified_value_precision") == 5 / 6
+    # No top-level array, so array_record does not emit. Unified still walks the
+    # nested claims/services arrays.
+    assert arr == []
+
+
+def test_array_records_with_nested_object_and_nested_object_array() -> None:
+    """Array of records whose columns mix a nested object and a nested object-array."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": ["string", "null"]},
+                        "addr": {
+                            "type": "object",
+                            "properties": {
+                                "city": {"type": ["string", "null"]},
+                                "geo": {
+                                    "type": "object",
+                                    "properties": {
+                                        "lat": {"type": ["string", "null"]},
+                                        "lon": {"type": ["string", "null"]},
+                                    },
+                                },
+                            },
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {"name": {"type": ["string", "null"]}},
+                            },
+                        },
+                    },
+                },
+            }
+        },
+    }
+    expected = {
+        "rows": [
+            {
+                "id": "1",
+                "addr": {"city": "A", "geo": {"lat": "1", "lon": "2"}},
+                "tags": [{"name": "x"}, {"name": "y"}],
+            }
+        ]
+    }
+    actual = {
+        "rows": [
+            {
+                "id": "1",
+                "addr": {"city": "A", "geo": {"lat": "1", "lon": "WRONG"}},
+                "tags": [{"name": "y"}, {"name": "x"}],
+            }
+        ]
+    }
+    rules = [
+        _rule("rows[0].id", "1"),
+        _rule("rows[0].addr.city", "A"),
+        _rule("rows[0].addr.geo.lat", "1"),
+        _rule("rows[0].addr.geo.lon", "2"),
+        _rule("rows[0].tags[0].name", "x"),
+        _rule("rows[0].tags[1].name", "y"),
+    ]
+    uni = compute_unified_evidence_metrics(expected, actual, rules, [], schema)
+    arr = ArrayRecordMatchMetric().compute(expected=expected, actual=actual, data_schema=schema)
+    # id, city, lat match; lon misses; tags Hungarian-match both names.
+    assert _val(uni, "extract_unified_value_recall") == 5 / 6
+    assert _val(uni, "extract_unified_value_precision") == 5 / 6
+    # array_record: id matches; addr and tags are opaque mismatches → 1/3.
+    assert _val(arr, "array_record_recall") == 1 / 3
+    assert _val(uni, "extract_unified_value_recall") > _val(arr, "array_record_recall")
+
+
 # ------------------------------------------------------------- grounding
 def _bbox_rules(expected: dict[str, Any], page: int, bbox: list[float]) -> list[ExtractFieldTestRule]:
     rules = [_rule("as_of", expected.get("as_of"))]
@@ -342,6 +601,21 @@ def test_grounded_requires_matching_bbox() -> None:
     assert _val(uni_bad, "extract_unified_grounded_recall") == 0.0
 
 
+def test_indexers_emit_validated_xywh_tuples() -> None:
+    box = [0.1, 0.2, 0.3, 0.4, 99.0]
+    rules = [_rule("as_of", "x", page=1, bbox=box)]
+    _, ev_boxes, _, *_ = build_rule_indexes(rules)
+    pred_boxes, _ = index_citations([{"field_path": "as_of", "page": 1, "bbox": box}])
+    assert ev_boxes["as_of"] == [(1, (0.1, 0.2, 0.3, 0.4))]
+    assert pred_boxes["as_of"] == [(1, (0.1, 0.2, 0.3, 0.4))]
+
+
+def test_iou_xywh_clamps_identical_non_dyadic_boxes_to_one() -> None:
+    box = (0.1, 0.2, 0.3, 0.4)
+    assert iou_xywh(box, box) == 1.0
+    assert iou_xywh(box, (0.9, 0.9, 0.05, 0.05)) == 0.0
+
+
 def test_no_citations_yields_zero_grounded() -> None:
     # GT carries bboxes (grounding IS applicable) but the prediction emits no
     # citation: a real grounding miss -> grounded F1 is emitted as 0.0.
@@ -357,7 +631,9 @@ def test_no_gt_bbox_omits_grounded_metrics() -> None:
     # When the ground truth carries NO evidence bbox, grounding is undefined:
     # the *_grounded_* metrics are omitted entirely (so the runner excludes the
     # document from the grounded average) even if the prediction emits boxes.
-    # The *_value_* metrics are unaffected.
+    # The *_value_* metrics are unaffected. This is the fix for a dataset whose
+    # GT lacks bboxes scoring a misleading ~0 grounded F1 instead of being
+    # excluded.
     expected = {"as_of": None, "holdings": [{"security": "AAA", "coupon": 1.0, "note": "n"}]}
     actual = {"as_of": None, "holdings": [{"security": "AAA", "coupon": 1.0, "note": "n"}]}
     rules = _leaf_rules_single(expected)  # no bbox on any GT evidence
@@ -495,7 +771,7 @@ def test_no_gt_page_omits_page_metrics() -> None:
 
 def test_nested_grounding_survives_outer_array_reorder() -> None:
     # Regression for the gt/pred path bug: when the outer object-array is
-    # reordered, nested-record citations must be looked up at the *matched
+    # reordered, nested object-array citations must be looked up at the *matched
     # predicted* index, not the GT index. With correct citations on the actual
     # prediction paths, grounded recall must stay 1.0.
     schema = {
@@ -600,7 +876,7 @@ def test_extract_evaluator_emits_unified_metrics() -> None:
 # ----------------------------------------- exact-row peel is pairing-safe only
 # The exact-row peel preserves array_record's value score (pairing-independent:
 # correct == n_pairs*k - total_cost). But the unified score is *pairing-sensitive*
-# whenever it recurses into nested sub-records or scores per-cell grounding, since
+# whenever it recurses into nested object arrays or scores per-cell grounding, since
 # both key off the matched predicted index. There the peel could select a
 # different (equal-cost) pairing than the full assignment and shift grounded /
 # nested true positives, so it must fall back to full assignment.
@@ -642,13 +918,26 @@ _NESTED_PEEL_SCHEMA: dict[str, Any] = {
 def _spy_on_peel(monkeypatch: Any) -> list[list[str]]:
     """Record the cost-subfields each exact-row peel call aligned on."""
     calls: list[list[str]] = []
-    original = unified_evidence_metric._peel_exact_row_matches
+    original = unified_evidence_metric.peel_exact_row_matches
 
-    def _spy(act_rows: Any, exp_rows: Any, subfields: Any, fuzzy: Any) -> Any:
+    def _spy(
+        act_rows: Any,
+        exp_rows: Any,
+        *,
+        subfields: Any,
+        fuzzy_field_thresholds: Any,
+        field_schemas: Any = None,
+    ) -> Any:
         calls.append(list(subfields))
-        return original(act_rows, exp_rows, subfields, fuzzy)
+        return original(
+            act_rows,
+            exp_rows,
+            subfields=subfields,
+            fuzzy_field_thresholds=fuzzy_field_thresholds,
+            field_schemas=field_schemas,
+        )
 
-    monkeypatch.setattr(unified_evidence_metric, "_peel_exact_row_matches", _spy)
+    monkeypatch.setattr(unified_evidence_metric, "peel_exact_row_matches", _spy)
     return calls
 
 
@@ -659,13 +948,13 @@ def test_exact_peel_used_for_flat_ungrounded_arrays(monkeypatch: Any) -> None:
     assert ["id", "value"] in calls, "flat un-grounded arrays must keep the fast exact-row peel"
 
 
-def test_exact_peel_skipped_for_nested_record_subfields(monkeypatch: Any) -> None:
+def test_exact_peel_skipped_for_object_array_subfields(monkeypatch: Any) -> None:
     calls = _spy_on_peel(monkeypatch)
     rows = [{"id": "A", "kids": [{"v": "x"}]}, {"id": "B", "kids": [{"v": "y"}]}]
     compute_unified_evidence_metrics({"rows": rows}, {"rows": rows}, [], [], _NESTED_PEEL_SCHEMA)
-    # The outer array (identity cell "id") has nested sub-records, so its
+    # The outer array (identity cell "id") has a nested object array, so its
     # alignment must use full assignment -- the peel must not see ["id"].
-    assert ["id"] not in calls, "outer array with sub-records must use full assignment"
+    assert ["id"] not in calls, "outer array with object-array subfields must use full assignment"
     # The inner flat "kids" arrays are opaque-cell-only, so they still peel.
     assert ["v"] in calls, "flat inner sub-arrays should still use the fast peel"
 
@@ -695,7 +984,7 @@ def test_exact_peel_skipped_when_cell_grounding_present(monkeypatch: Any) -> Non
     assert calls == [], "per-cell grounding makes scoring pairing-sensitive; must use full assignment"
 
 
-def test_nested_record_full_assignment_scores_perfect_match() -> None:
+def test_object_array_full_assignment_scores_perfect_match() -> None:
     # Sanity: the full-assignment fallback still scores a perfect nested match.
     rows = [{"id": "A", "kids": [{"v": "x"}]}, {"id": "B", "kids": [{"v": "y"}]}]
     uni = compute_unified_evidence_metrics({"rows": rows}, {"rows": rows}, [], [], _NESTED_PEEL_SCHEMA)
@@ -960,8 +1249,8 @@ def test_giant_grounded_array_skips_grounding_value_exact_and_peels(monkeypatch:
 
 
 def test_giant_threshold_does_not_touch_nested_or_below_threshold(monkeypatch: Any) -> None:
-    """The skip must not fire for arrays with sub-records (peel would shift
-    nested TP), nor below the threshold."""
+    """The skip must not fire for arrays with nested object arrays (peel would shift
+    nested TP -- the #1537 hazard), nor below the threshold."""
     box = [0.0, 0.0, 10.0, 10.0]
     expected = {"as_of": None, "holdings": [{"security": "A", "coupon": 1.0, "note": "n"}]}
     rules = _bbox_rules(expected, page=1, bbox=box)
@@ -971,7 +1260,7 @@ def test_giant_threshold_does_not_touch_nested_or_below_threshold(monkeypatch: A
     assert _val(kept, "extract_unified_grounded_f1") == 1.0
     assert next(m for m in kept if m.metric_name == "extract_unified_value_f1").metadata["grounded_incomplete"] is False
 
-    # A nested-record array over the threshold must NOT skip (stays grounded via
+    # An object-array nested over the threshold must NOT skip (stays grounded via
     # full assignment) because the peel there could shift nested TP.
     monkeypatch.setattr(unified_evidence_metric, "_GROUNDED_MAX_CELLS", 1)
     nested = {"rows": [{"id": "A", "kids": [{"v": "x"}]}]}
@@ -984,5 +1273,16 @@ def test_giant_threshold_does_not_touch_nested_or_below_threshold(monkeypatch: A
         {"field_path": "rows[0].kids[0].v", "page": 1, "bbox": box},
     ]
     out = compute_unified_evidence_metrics(nested, nested, nrules, ncits, _NESTED_PEEL_SCHEMA)
-    # Outer array has sub-records -> not eligible for the skip -> grounding kept.
+    # Outer array has an object-array subfield -> not eligible for the skip -> grounding kept.
     assert _val(out, "extract_unified_grounded_f1") == 1.0
+
+
+_HEADLINE_UNIFIED_PREFIXES = (
+    "extract_unified_value_",
+    "extract_unified_page_",
+    "extract_unified_grounded_",
+)
+
+
+def _is_headline_unified(name: str) -> bool:
+    return name.startswith(_HEADLINE_UNIFIED_PREFIXES) and "_word_" not in name and "_structural_" not in name

--- a/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
@@ -479,6 +479,27 @@ def test_empty_gt_object_array_expands_predicted_children() -> None:
         assert _val(uni, "extract_unified_value_precision") == 0.2
 
 
+def test_gold_list_does_not_make_a_string_field_an_array() -> None:
+    """Eval shape comes from schema, not the gold value's Python type."""
+    schema = {"type": "object", "properties": {"note": {"type": ["string", "null"]}}}
+    expected = {"note": [{"text": "a"}, {"text": "b"}]}
+    actual = {"note": [{"text": "a"}, {"text": "b"}]}
+    uni = compute_unified_evidence_metrics(expected, actual, [], [], schema)
+    # One opaque string-field cell (the lists compare equal), not 2 Hungarian rows.
+    assert _val(uni, "extract_unified_value_recall") == 1.0
+    assert _val(uni, "extract_unified_value_precision") == 1.0
+
+
+def test_gold_dict_does_not_make_a_string_field_an_object() -> None:
+    schema = {"type": "object", "properties": {"note": {"type": ["string", "null"]}}}
+    expected = {"note": {"text": "a"}}
+    actual = {"note": {"text": "b"}}
+    uni = compute_unified_evidence_metrics(expected, actual, [], [], schema)
+    # One opaque miss, not a child-cell recurse into ``text``.
+    assert _val(uni, "extract_unified_value_recall") == 0.0
+    assert _val(uni, "extract_unified_value_precision") == 0.0
+
+
 def test_object_wrapping_array_of_records_with_nested_object_arrays() -> None:
     """Root object → child object → array of records → nested object-array.
 

--- a/tests/extract_bench/inference/providers/extract/test_schema_utils.py
+++ b/tests/extract_bench/inference/providers/extract/test_schema_utils.py
@@ -1,0 +1,41 @@
+"""Helpers that flatten JSON Schema combinators for extract scoring."""
+
+from __future__ import annotations
+
+from extract_bench.inference.providers.extract.table_codegen.schema_utils import (
+    resolve_refs,
+    schema_items,
+    schema_properties,
+)
+
+
+def test_schema_properties_and_items_flatten_inlined_anyof_ref() -> None:
+    schema = {
+        "type": "object",
+        "$defs": {
+            "Vendor": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "city": {"type": "string"},
+                },
+            },
+            "Line": {
+                "type": "object",
+                "properties": {"sku": {"type": "string"}},
+            },
+        },
+        "properties": {
+            "vendor": {"anyOf": [{"$ref": "#/$defs/Vendor"}, {"type": "null"}]},
+            "lines": {
+                "anyOf": [
+                    {"type": "array", "items": {"$ref": "#/$defs/Line"}},
+                    {"type": "null"},
+                ]
+            },
+        },
+    }
+    resolved = resolve_refs(schema)
+    assert set(schema_properties(resolved["properties"]["vendor"])) == {"name", "city"}
+    items = schema_items(resolved["properties"]["lines"])
+    assert set(schema_properties(items)) == {"sku"}


### PR DESCRIPTION
## Summary
- Walk object-valued fields the same way ExtractBench already walks arrays of objects: each child is its own value cell, including objects nested on array rows.
- Read item/object properties through JSON Schema combinators (`anyOf` / `oneOf` / `allOf`) after `$ref` inlining, so nullable object and array wrappers still expose their fields.
- Empty or null gold object-arrays still expand from the item schema, so invented predicted children are per-field precision misses rather than one opaque cell.
- Array vs object vs scalar (and which nested columns recurse) is decided from the schema only, not from whether gold or pred happens to be a list or dict.
- `array_record` inlines `$ref` before reading `items.properties`, same as the unified scorer, so `$defs` item schemas still produce columns.
- Small typing cleanups on the array-record helpers (`Sequence` / `Mapping`) and a couple of bbox ingest/IoU numeric guards. Headline grounded/page metrics are unchanged in shape.

## Test plan
- [x] `uv run pytest tests/extract_bench/evaluation/metrics/extract tests/extract_bench/inference/providers/extract/test_schema_utils.py tests/extract_bench/evaluation/evaluators/test_extract_field_metrics.py`
- [x] `uv run ruff check && uv run ruff format --check`