### PR TITLE
Add GPT-6 Astra extract one-shot pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ Models and prices reflect each provider's official documentation as of July 1, 2
 
 | Rank | Provider | Category | Overall | Short | Medium | Long | ¢ / Page |
 |---:|---|---|---:|---:|---:|---:|---:|
-| 1 | LlamaExtract Agentic Plus | LlamaExtract | **95.59** | **96.56** | **93.34** | **94.41** | 8.11¢ |
+| 1 | LlamaExtract Agentic Plus | LlamaExtract | **95.59** | <u>96.56</u> | **93.34** | **94.41** | 8.11¢ |
 | 2 | Codex (GPT-5.5) | Coding Agents | <u>93.57</u> | 95.68 | <u>91.15</u> | 78.88 | 27.83¢ |
-| 3 | Reducto Deep Extract | Specialized APIs | 90.44 | 94.20 | 80.47 | <u>92.01</u> | 34.44¢ |
-| 4 | Qwen3.8 Flash Next | OSS | 89.88 | 94.82 | 87.81 | 37.74 | — |
-| 5 | Qwen3.8 27B | OSS | 89.75 | 94.68 | 87.54 | 38.45 | — |
-| 6 | LlamaExtract Agentic | LlamaExtract | 89.55 | 92.03 | 85.41 | 78.62 | 3.12¢ |
-| 7 | Extend (Max Context) | Specialized APIs | 88.62 | 92.32 | 78.75 | 90.46 | 10.00¢ |
-| 8 | Qwen3.6 35B | OSS | 88.11 | 92.86 | 86.37 | 36.90 | — |
-| 9 | Qwen3.5 35B | OSS | 88.00 | 93.52 | 85.27 | 31.73 | — |
-| 10 | Claude Code (Opus 4.8) | Coding Agents | 87.09 | 90.08 | 79.21 | 88.07 | 16.17¢ |
+| 3 | OpenAI GPT-6 Astra | Commercial VLM | 91.91 | **97.22** | 90.56 | 31.70 | 11.09¢ |
+| 4 | Reducto Deep Extract | Specialized APIs | 90.44 | 94.20 | 80.47 | <u>92.01</u> | 34.44¢ |
+| 5 | Qwen3.8 Flash Next | OSS | 89.88 | 94.82 | 87.81 | 37.74 | — |
+| 6 | Qwen3.8 27B | OSS | 89.75 | 94.68 | 87.54 | 38.45 | — |
+| 7 | LlamaExtract Agentic | LlamaExtract | 89.55 | 92.03 | 85.41 | 78.62 | 3.12¢ |
+| 8 | Extend (Max Context) | Specialized APIs | 88.62 | 92.32 | 78.75 | 90.46 | 10.00¢ |
+| 9 | Qwen3.6 35B | OSS | 88.11 | 92.86 | 86.37 | 36.90 | — |
+| 10 | Qwen3.5 35B | OSS | 88.00 | 93.52 | 85.27 | 31.73 | — |
 
-Top 10 of 34 systems — full table in [leaderboard.csv](leaderboard.csv).
+Top 10 of 36 systems — full table in [leaderboard.csv](leaderboard.csv).
 <!-- LEADERBOARD:END -->
 
 <!-- GROUNDING:START -->
@@ -54,7 +54,7 @@ Top 10 of 34 systems — full table in [leaderboard.csv](leaderboard.csv).
     <tr><td align="right">5</td><td>Extend (Max Context)</td><td align="right">25.20</td><td align="right">33.93</td><td align="right">0.21</td><td align="right">0.02</td><td align="right">49.04</td><td align="right">61.71</td><td align="right">27.68</td><td align="right">0.03</td></tr>
     <tr><td align="right">6</td><td>Extend Extract</td><td align="right">15.96</td><td align="right">21.13</td><td align="right">1.03</td><td align="right">0.01</td><td align="right">53.58</td><td align="right">64.50</td><td align="right">37.39</td><td align="right">0.03</td></tr>
     <tr><td align="right">7</td><td>Datalab (Accurate + Balanced)</td><td align="right">2.02</td><td align="right">2.67</td><td align="right">0.24</td><td align="right">0.00</td><td align="right">48.50</td><td align="right">56.90</td><td align="right">38.55</td><td align="right">0.01</td></tr>
-    <tr><td align="right">—</td><td><em>All 27 other systems</em></td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td></tr>
+    <tr><td align="right">—</td><td><em>All 29 other systems</em></td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td><td align="right">0.00</td></tr>
   </tbody>
 </table>
 <!-- GROUNDING:END -->

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -21,6 +21,7 @@ uv run extract-bench run <pipeline_name>
 | `llamaextract_agentic_plus` | LlamaExtract V2 API | highest tier; returns word-level citation boxes natively, no parse pass needed |
 | `llamaextract_cost_effective_standard_bbox` / `llamaextract_agentic_standard_bbox` | LlamaExtract V2 API | same tiers with block-level citation boxes and no granular parse pass |
 | `openai_gpt_5_4_extract_oneshot_structured_output_file` (+ `_nano`) | OpenAI Responses | one-shot structured output over the uploaded file |
+| `openai_gpt_6_astra_reasoning_low_extract_oneshot_structured_output_file` | OpenAI Responses | one-shot structured output over the uploaded file (reasoning: low) |
 | `gemini_3_5_flash_extract_oneshot_structured_output_file` | Gemini | one-shot structured output (thinking: low) |
 | `gemini_3_6_flash_extract_oneshot_structured_output_file` | Gemini | one-shot structured output (thinking: medium) |
 | `gemini_3_7_flash_extract_oneshot_structured_output_file` | Gemini | one-shot structured output (thinking: medium) |

--- a/leaderboard.csv
+++ b/leaderboard.csv
@@ -1,6 +1,7 @@
 Provider,Category,Overall,Short,Medium,Long,Cost_Per_Page,Cost_Short,Cost_Medium,Cost_Long,P_Short,P_Medium,P_Long,R_Short,R_Medium,R_Long,Word_Grounding,Word_Grounding_Short,Word_Grounding_Medium,Word_Grounding_Long,Page_Grounding,Page_Grounding_Short,Page_Grounding_Medium,Page_Grounding_Long,Latency_S_Per_Doc_Short,Latency_S_Per_Doc_Medium,Latency_S_Per_Doc_Long
 LlamaExtract Agentic Plus,LlamaExtract,95.59,96.56,93.34,94.41,0.0811,0.0831,0.0771,0.0750,96.59,93.95,94.32,96.54,92.80,94.54,46.43,43.74,54.01,54.67,84.92,89.70,72.25,87.14,110.7,197.7,587.5
 Codex (GPT-5.5),Coding Agents,93.57,95.68,91.15,78.88,0.2783,0.3579,0.1214,0.0434,96.01,93.64,94.03,95.51,90.16,78.58,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,70.3,82.6,122.0
+OpenAI GPT-6 Astra,Commercial VLM,91.91,97.22,90.56,31.70,0.1109,0.1320,0.0677,0.0382,97.14,92.08,75.58,97.32,90.16,29.87,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,35.0,106.4,90.1
 Reducto Deep Extract,Specialized APIs,90.44,94.20,80.47,92.01,0.3444,0.3798,0.2312,0.5058,94.09,80.78,91.98,94.38,80.20,92.06,43.30,42.84,45.57,41.13,71.71,72.60,70.42,67.28,206.5,293.7,591.7
 Reducto Extract,Specialized APIs,83.41,92.97,69.59,30.65,0.0553,0.0576,0.0517,0.0483,92.88,79.07,93.03,93.17,68.75,29.51,0.00,0.00,0.00,0.00,0.00,0.00,0.00,0.00,34.5,141.0,56.3
 Extend Extract,Specialized APIs,85.72,89.39,84.14,47.21,0.0680,0.0698,0.0644,0.0625,89.60,85.98,51.76,89.33,84.31,47.29,15.96,21.13,1.03,0.01,53.58,64.50,37.39,0.03,122.3,104.5,170.5

--- a/src/extract_bench/inference/pipelines/extract.py
+++ b/src/extract_bench/inference/pipelines/extract.py
@@ -85,6 +85,18 @@ def register_extract_pipelines(register_fn) -> None:  # type: ignore[no-untyped-
 
     register_fn(
         _pipeline_spec(
+            pipeline_name="openai_gpt_6_astra_reasoning_low_extract_oneshot_structured_output_file",
+            provider_name="openai_extract",
+            config={
+                "model": "gpt-6-astra",
+                "additional_properties_false": True,
+                "reasoning_effort": "low",
+            },
+        )
+    )
+
+    register_fn(
+        _pipeline_spec(
             pipeline_name="openai_gpt_5_4_extract_oneshot_structured_output_file",
             provider_name="openai_extract",
             config={

--- a/src/extract_bench/inference/providers/extract/openai_responses.py
+++ b/src/extract_bench/inference/providers/extract/openai_responses.py
@@ -94,6 +94,7 @@ DEFAULT_USER_INSTRUCTION = (
 # OpenAI pricing: USD per million tokens (input, output).
 # Uses longest-prefix matching to support dated model ids.
 _OPENAI_RESPONSES_EXTRACT_PRICING_PER_M: dict[str, tuple[float, float]] = {
+    "gpt-6-astra": (10.00, 50.00),
     "gpt-5.4-nano": (0.20, 1.25),
     "gpt-5.4-mini": (0.75, 4.50),
     "gpt-5.4": (2.50, 15.00),
@@ -165,6 +166,10 @@ class OpenAIResponsesExtractProvider(Provider):
         self._additional_properties_false: bool = bool(self.base_config.get("additional_properties_false", True))
         self._system_prompt: str = self.base_config.get("system_prompt", DEFAULT_SYSTEM_PROMPT)
         self._user_instruction: str = self.base_config.get("user_instruction", DEFAULT_USER_INSTRUCTION)
+        # Reasoning effort for reasoning-capable models (gpt-6-astra: low/medium/
+        # high/xhigh/max). Only sent to the Responses API when set — non-reasoning
+        # models 400 on a reasoning param, so pipelines that omit it are unchanged.
+        self._reasoning_effort: str | None = self.base_config.get("reasoning_effort")
 
         self._input_mode: str = self.base_config.get("input_mode", "file")
         if self._input_mode not in ("file", "parsed_text"):
@@ -267,22 +272,25 @@ class OpenAIResponsesExtractProvider(Provider):
         # constructing the user content via a helper drops mypy's ability to
         # narrow it. The shape is correct at runtime, so silence the overload
         # mismatch here rather than duplicating both branches at the call site.
+        create_kwargs: dict[str, Any] = {
+            "model": self._model,
+            "input": [
+                {"role": "system", "content": self._system_prompt},
+                {"role": "user", "content": user_content},
+            ],
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": self._schema_name,
+                    "schema": schema,
+                    "strict": self._strict,
+                }
+            },
+        }
+        if self._reasoning_effort is not None:
+            create_kwargs["reasoning"] = {"effort": self._reasoning_effort}
         try:
-            resp = self._client.responses.create(  # type: ignore[call-overload]
-                model=self._model,
-                input=[
-                    {"role": "system", "content": self._system_prompt},
-                    {"role": "user", "content": user_content},
-                ],
-                text={
-                    "format": {
-                        "type": "json_schema",
-                        "name": self._schema_name,
-                        "schema": schema,
-                        "strict": self._strict,
-                    }
-                },
-            )
+            resp = self._client.responses.create(**create_kwargs)
         finally:
             if uploaded_file_id is not None:
                 try:


### PR DESCRIPTION
## What
Adds the GPT-6 Astra one-shot structured-output extract pipeline and its leaderboard entry.

## Why
Benchmark GPT-6 Astra on ExtractBench alongside the existing one-shot LLM/VLM extractors.

## How
- Register `openai_gpt_6_astra_reasoning_low_extract_oneshot_structured_output_file` (provider `openai_extract`, `reasoning_effort: low`), matching the existing one-shot sibling config shape.
- Wire `reasoning_effort` through the OpenAI Responses provider — forwarded to the API as `reasoning.effort` only when set, so non-reasoning pipelines are unaffected.
- Add `gpt-6-astra` pricing ($10/M input, $50/M output) to the provider pricing table.
- Add the leaderboard row (Overall 91.91; Short 97.22 / Medium 90.56 / Long 31.70) and regenerate the README tables.

## Changes
- `src/extract_bench/inference/pipelines/extract.py` — new pipeline spec
- `src/extract_bench/inference/providers/extract/openai_responses.py` — pricing entry + reasoning wiring
- `docs/pipelines.md` — pipeline row
- `leaderboard.csv` — new row (rank 3)
- `README.md` — regenerated from the leaderboard

## Testing
- `uv run extract-bench pipelines | grep gpt_6_astra` resolves the new pipeline
- `uv run ruff check` passes on the changed files
- `uv run python scripts/update_readme.py` — diff confined to the generated table blocks

## Notes
Requires `OPENAI_API_KEY` (no new env var). Grounding columns are 0.00 — one-shot structured output emits no citation boxes.