### PR TITLE
Score nested arrays, pairing cost, and schema defaults in extract value F1

### DIFF
--- a/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
@@ -13,8 +13,6 @@ from rapidfuzz import fuzz
 from scipy.optimize import linear_sum_assignment
 
 from extract_bench.evaluation.metrics.extract.json_subset_match import (
-    _is_nullable_numeric_field,
-    _normalize_nullable_numeric,
     normalize_date_string,
 )
 from extract_bench.inference.providers.extract.table_codegen.schema_utils import (
@@ -140,11 +138,7 @@ def cell_match[K: CellKey](
         )
     if isinstance(expected, str) and isinstance(actual, str):
         return normalize_ws(expected) == normalize_ws(actual)
-    # Nullable numeric fields treat 0 / 0.0 and None as equivalent. Gated on
-    # the JSON Schema shape so plain numeric fields keep strict semantics.
-    if _is_nullable_numeric_field(field_schema):
-        expected = _normalize_nullable_numeric(expected)
-        actual = _normalize_nullable_numeric(actual)
+    # JSON scalars compare with ``==`` (``0 != None``).
     return bool(expected == actual)
 
 
@@ -203,14 +197,11 @@ def _cell_key(
     the same way scalars already do. Returns ``_UNHASHABLE`` when a cell still
     cannot be interned -> caller scores that column pairwise.
 
-    When ``field_schema`` is a nullable-numeric shape, ``0`` / ``0.0`` collapse
-    to ``None`` in the key so that null-vs-zero cells intern to the same slot,
-    matching the equality relaxation in ``cell_match``.
+    ``field_schema`` matches ``cell_match``'s keyword; intern keys come from
+    the value (whitespace-folded strings, tagged scalars, frozen JSON).
     """
     if isinstance(value, str):
         return ("s", normalize_ws(value))
-    if _is_nullable_numeric_field(field_schema):
-        value = _normalize_nullable_numeric(value)
     if isinstance(value, (list, dict)):
         return _eq_key(value)
     try:
@@ -250,37 +241,38 @@ def _intern_field[K: CellKey](
     return out[0], out[1]
 
 
-def _row_match_key(
+def _row_match_key[K: CellKey](
     row: Any,
-    subfields: Sequence[str],
-    field_schemas: Mapping[str, Any] | None = None,
+    subfields: Sequence[K],
+    field_schemas: Mapping[K, Any] | None = None,
 ) -> tuple[Any, ...] | None:
     """Hashable full-row key whose equality implies zero assignment cost."""
     row_dict = row if isinstance(row, dict) else {}
     parts: list[Any] = []
+    schemas: Mapping[K, Any] = field_schemas if field_schemas is not None else {}
     for field in subfields:
         value = row_dict.get(field)
-        cell_key = _cell_key(value, (field_schemas or {}).get(field))
+        cell_key = _cell_key(value, schemas.get(field))
         if cell_key is _UNHASHABLE:
             return None
         parts.append(cell_key)
     return tuple(parts)
 
 
-def _can_peel_exact_rows(
-    subfields: Sequence[str],
-    fuzzy_field_thresholds: Mapping[str, float],
+def _can_peel_exact_rows[K: CellKey](
+    subfields: Sequence[K],
+    fuzzy_field_thresholds: Mapping[K, float],
 ) -> bool:
     return all(fuzzy_field_thresholds.get(field) is None for field in subfields)
 
 
-def peel_exact_row_matches(
-    actual_list: list[Any],
-    expected_list: list[Any],
+def peel_exact_row_matches[K: CellKey](
+    actual_list: Sequence[Any],
+    expected_list: Sequence[Any],
     *,
-    subfields: Sequence[str],
-    fuzzy_field_thresholds: Mapping[str, float],
-    field_schemas: Mapping[str, Any] | None = None,
+    subfields: Sequence[K],
+    fuzzy_field_thresholds: Mapping[K, float],
+    field_schemas: Mapping[K, Any] | None = None,
 ) -> _RowAssignment:
     """Pre-align zero-cost rows before building an expensive residual matrix.
 
@@ -307,7 +299,7 @@ def peel_exact_row_matches(
     for expected_idx, row in enumerate(expected_list):
         key = _row_match_key(row, subfields, field_schemas)
         bucket = actual_by_key.get(key) if key is not None else None
-        if bucket:
+        if bucket is not None and len(bucket) > 0:
             actual_idx = bucket.popleft()
             pairs.append((actual_idx, expected_idx))
             matched_actual.add(actual_idx)

--- a/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/array_record_match_metric.py
@@ -47,6 +47,10 @@ DEFAULT_FUZZY_FIELD_THRESHOLDS: dict[str, float] = {
     "court": 0.85,
 }
 
+# Intern / Hungarian column id: a JSON key on a raw row (`str`) or a flattened
+# pairing path (`tuple[str, ...]`). A singleton tuple is not a JSON key.
+type CellKey = str | tuple[str, ...]
+
 
 @dataclass(frozen=True)
 class ArrayRecordMatchCounts:
@@ -117,12 +121,12 @@ def normalize_ws(value: str) -> str:
     return _WS_RE.sub(" ", value).strip()
 
 
-def cell_match(
+def cell_match[K: CellKey](
     expected: Any,
     actual: Any,
-    field: str,
+    field: K,
     *,
-    fuzzy_field_thresholds: Mapping[str, float],
+    fuzzy_field_thresholds: Mapping[K, float],
     field_schema: Any = None,
 ) -> bool:
     threshold = fuzzy_field_thresholds.get(field)
@@ -216,10 +220,10 @@ def _cell_key(
     return ("v", value)
 
 
-def _intern_field(
+def _intern_field[K: CellKey](
     actual_list: Sequence[Any],
     expected_list: Sequence[Any],
-    field: str,
+    field: K,
     field_schema: Any = None,
 ) -> tuple[np.ndarray, np.ndarray] | None:
     """Map each row's ``field`` cell to an int id shared across both sides.
@@ -318,13 +322,13 @@ def peel_exact_row_matches(
     )
 
 
-def mismatch_cost_matrix(
-    actual_list: list[Any],
-    expected_list: list[Any],
+def mismatch_cost_matrix[K: CellKey](
+    actual_list: Sequence[Any],
+    expected_list: Sequence[Any],
     *,
-    subfields: Sequence[str],
-    fuzzy_field_thresholds: Mapping[str, float],
-    field_schemas: Mapping[str, Any] | None = None,
+    subfields: Sequence[K],
+    fuzzy_field_thresholds: Mapping[K, float],
+    field_schemas: Mapping[K, Any] | None = None,
 ) -> np.ndarray:
     """Vectorized ``(n_actual, n_expected)`` matrix of mismatched-subfield counts.
 

--- a/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
@@ -26,11 +26,12 @@ three additions:
    array. A missing key uses that field's JSON Schema ``default`` when the
    keyword is present; without ``default`` the key is absent (one-sided miss),
    not an implicit ``null``. ``lookup`` fills values; it does not pick the
-   scorer. The same lookup is used at the root, inside nested objects, and on
-   object columns of array rows after Hungarian pairing. Opaque array cells
-   stay ``array_record``'s ``.get``. Row-pairing cost uses those same children
-   (and nested object-arrays) so Hungarian maximizes the cells F1 actually
-   scores. Scalar lists stay opaque.
+   scorer. The same lookup is used at the root, inside nested objects, on
+   object columns of array rows after Hungarian pairing, and when reading
+   nested leaves for pairing cost. Opaque array cells stay ``array_record``'s
+   ``.get``. Row-pairing cost uses those same children (and nested
+   object-arrays) so Hungarian maximizes the cells F1 actually scores.
+   Scalar lists stay opaque.
 3. **Grounding (bbox + page).** Two parallel sets of counters, both value-gated
    and both nesting under the value score. A cell is *grounded-correct* when the
    value matches AND the prediction's citation has a bbox that overlaps an
@@ -353,16 +354,29 @@ def _read_segments(
     row: Any,
     *,
     segments: Sequence[str],
+    item_sch: Mapping[str, Any],
 ) -> Any:
-    """Walk successive mapping keys; a missing step is an implicit ``None`` cell.
+    """Walk successive mapping keys, applying ``lookup`` at each step.
 
     Keys are not split, so a schema field named ``a.b`` is one step, not two.
+    Omitted keys use JSON Schema ``default`` when present, matching F1.
+    A missing key with no ``default`` stops the walk as ``None``. A present
+    non-object (including explicit ``null``) is coerced to ``{}`` before the
+    next step, the same way ``_score_node`` walks children.
     """
     cur: Any = row if isinstance(row, Mapping) else {}
-    for part in segments:
+    field_schema: Any = {}
+    for i, part in enumerate(segments):
+        if i == 0:
+            field_schema = item_sch.get(part, {})
+        else:
+            props = schema_properties(field_schema) if isinstance(field_schema, Mapping) else {}
+            field_schema = props.get(part, {})
         if not isinstance(cur, Mapping):
+            cur = {}
+        present, cur = lookup(cur, part, field_schema)
+        if not present:
             return None
-        cur = cur.get(part)
     return cur
 
 
@@ -419,8 +433,9 @@ def _flatten_pairing_rows(
     rows: Sequence[Any],
     *,
     paths: Sequence[PairingPath],
+    item_sch: Mapping[str, Any],
 ) -> Sequence[Mapping[PairingPath, Any]]:
-    return [{path: _read_segments(row, segments=path) for path in paths} for row in rows]
+    return [{path: _read_segments(row, segments=path, item_sch=item_sch) for path in paths} for row in rows]
 
 
 def _fuzzy_for_paths(
@@ -523,6 +538,7 @@ class Scorer:
         exp_rows: Sequence[Any],
         pairing_paths: Sequence[PairingPath],
         gt_field: str,
+        item_sch: Mapping[str, Any],
     ) -> bool:
         """True when this level's opaque pairing cells have a distinct alt or a normalizer.
 
@@ -538,7 +554,7 @@ class Scorer:
                 alt = self._alt.get(gt_path)
                 if not alt:
                     continue
-                canon = _read_segments(erow, segments=path)
+                canon = _read_segments(erow, segments=path, item_sch=item_sch)
                 if any(value != canon for value in alt):
                     return True
         return False
@@ -569,7 +585,9 @@ class Scorer:
             item_sch=item_sch,
             subfield_names=names,
             gt_field=gt_path,
-            use_alts=self._gold_needs_configured_match(exp_rows=exp_rows, pairing_paths=inner_paths, gt_field=gt_path),
+            use_alts=self._gold_needs_configured_match(
+                exp_rows=exp_rows, pairing_paths=inner_paths, gt_field=gt_path, item_sch=item_sch
+            ),
         )
         row_ind, col_ind = linear_sum_assignment(inner)
         paired = int(inner[row_ind, col_ind].sum())
@@ -611,7 +629,7 @@ class Scorer:
             for i, erow in enumerate(exp_rows):
                 row_cands = []
                 for path in paths:
-                    canon = _read_segments(erow, segments=path)
+                    canon = _read_segments(erow, segments=path, item_sch=item_sch)
                     alt = self._alt.get(f"{gt_field}[{i}].{_gt_rel_path(path)}")
                     cand = [canon]
                     if alt:
@@ -619,7 +637,7 @@ class Scorer:
                     row_cands.append(cand)
                 exp_cands.append(row_cands)
             for j, arow in enumerate(act_rows):
-                avals = [_read_segments(arow, segments=path) for path in paths]
+                avals = [_read_segments(arow, segments=path, item_sch=item_sch) for path in paths]
                 for i, cands in enumerate(exp_cands):
                     cost[j, i] = sum(
                         not any(
@@ -635,8 +653,8 @@ class Scorer:
                     )
         elif paths:
             cost = mismatch_cost_matrix(
-                _flatten_pairing_rows(act_rows, paths=paths),
-                _flatten_pairing_rows(exp_rows, paths=paths),
+                _flatten_pairing_rows(act_rows, paths=paths, item_sch=item_sch),
+                _flatten_pairing_rows(exp_rows, paths=paths, item_sch=item_sch),
                 subfields=paths,
                 fuzzy_field_thresholds=path_fuzzy,
                 field_schemas=path_schemas,
@@ -649,8 +667,8 @@ class Scorer:
                 for i, erow in enumerate(exp_rows):
                     extra[j, i] = sum(
                         self._object_array_pair_cost(
-                            _read_segments(erow, segments=path),
-                            _read_segments(arow, segments=path),
+                            _read_segments(erow, segments=path, item_sch=item_sch),
+                            _read_segments(arow, segments=path, item_sch=item_sch),
                             schema=array_schema,
                             gt_path=f"{gt_field}[{i}].{_gt_rel_path(path)}",
                         )
@@ -866,7 +884,9 @@ class Scorer:
             # Distinct alts / normalizers on *this* level's opaque cells expand the
             # zero-cost graph, so skip the exact-row peel. Nested object-arrays
             # detect configured match for themselves when they add their cost.
-            if self._gold_needs_configured_match(exp_rows=exp_rows, pairing_paths=pairing_paths, gt_field=gt_field):
+            if self._gold_needs_configured_match(
+                exp_rows=exp_rows, pairing_paths=pairing_paths, gt_field=gt_field, item_sch=item_sch
+            ):
                 cost = self._pairing_cost_matrix(
                     act_rows,
                     exp_rows,

--- a/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
@@ -19,9 +19,18 @@ three additions:
    ``entities[].aliases``) is recursed into and aligned with another Hungarian
    pass, scoring each of its fields, instead of being compared as one opaque
    cell. Bare objects (root, nested outside arrays, and objects on array rows)
-   are recursed into and scored per child cell with the same ``.get`` lookup the
-   root object uses; omit vs a gold object is implicit ``null`` children, not
-   one all-or-nothing miss. Scalar lists stay opaque.
+   are recursed into and scored per child cell. **Which comparison runs**
+   (Hungarian object-array, object child walk, or opaque scalar) is decided
+   by JSON Schema, including combinators — not by whether gold or pred is a
+   list or dict. A list in an extraction does not make a string field an
+   array. A missing key uses that field's JSON Schema ``default`` when the
+   keyword is present; without ``default`` the key is absent (one-sided miss),
+   not an implicit ``null``. ``lookup`` fills values; it does not pick the
+   scorer. The same lookup is used at the root, inside nested objects, and on
+   object columns of array rows after Hungarian pairing. Opaque array cells
+   stay ``array_record``'s ``.get``. Row-pairing cost uses those same children
+   (and nested object-arrays) so Hungarian maximizes the cells F1 actually
+   scores. Scalar lists stay opaque.
 3. **Grounding (bbox + page).** Two parallel sets of counters, both value-gated
    and both nesting under the value score. A cell is *grounded-correct* when the
    value matches AND the prediction's citation has a bbox that overlaps an
@@ -65,6 +74,7 @@ pass.
 
 from __future__ import annotations
 
+import math
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -155,10 +165,14 @@ type BoxIndex = dict[str, list[PageBBox]]
 
 
 def _validated_bbox(raw: Sequence[SupportsFloat]) -> BBox | None:
-    """Four COCO xywh floats, or None when the payload is shorter than xywh."""
+    """Four finite COCO xywh floats with positive size, else None."""
     if len(raw) < 4:
         return None
-    return (float(raw[0]), float(raw[1]), float(raw[2]), float(raw[3]))
+    box = (float(raw[0]), float(raw[1]), float(raw[2]), float(raw[3]))
+    _, _, w, h = box
+    if not all(map(math.isfinite, box)) or w <= 0 or h <= 0:
+        return None
+    return box
 
 
 @lru_cache(maxsize=8192)
@@ -276,6 +290,21 @@ def path_leaf(path: str) -> str:
     return path.rsplit(".", 1)[-1].split("[", 1)[0]
 
 
+def lookup(obj: Mapping[str, Any], key: str, field_schema: Mapping[str, Any] | Any) -> tuple[bool, Any]:
+    """Value of ``key`` on ``obj``, or the field's schema ``default`` if omitted.
+
+    A present key (including an explicit ``null``) wins. A missing key uses
+    ``default`` iff that keyword is present (including ``default: null``).
+    A missing key with no ``default`` keyword is absent — not filled with
+    ``null``.
+    """
+    if key in obj:
+        return True, obj[key]
+    if isinstance(field_schema, Mapping) and "default" in field_schema:
+        return True, field_schema["default"]
+    return False, None
+
+
 def is_object_array_schema(field_schema: Any) -> bool:
     """True when JSON Schema describes an array of objects (incl. combinators)."""
     if not isinstance(field_schema, Mapping):
@@ -317,9 +346,137 @@ def is_object_subfield(field_schema: Any) -> bool:
     return is_object_schema(field_schema)
 
 
+type PairingPath = tuple[str, ...]
+
+
+def _read_segments(
+    row: Any,
+    *,
+    segments: Sequence[str],
+) -> Any:
+    """Walk successive mapping keys; a missing step is an implicit ``None`` cell.
+
+    Keys are not split, so a schema field named ``a.b`` is one step, not two.
+    """
+    cur: Any = row if isinstance(row, Mapping) else {}
+    for part in segments:
+        if not isinstance(cur, Mapping):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+def _gt_rel_path(segments: Sequence[str]) -> str:
+    """Join key segments with ``.`` for ``field_path`` lookup (alts / normalizers)."""
+    return ".".join(segments)
+
+
+def _collect_pairing_fields(
+    *,
+    schema: Any,
+    prefix: PairingPath,
+) -> tuple[Sequence[tuple[PairingPath, Any]], Sequence[tuple[PairingPath, Any]]]:
+    """Opaque pairing cells and nested object-arrays under ``schema``.
+
+    Same descent as ``Scorer._score_node``: object-arrays are a nested Hungarian
+    unit; scalar arrays and scalars stay one opaque cell; objects expand to
+    properties so pairing cost counts the children F1 will score, not a 0/1
+    ``==`` on the whole dict.
+    """
+    if is_array_schema(schema):
+        if is_object_array_schema(schema):
+            return [], [(prefix, schema)]
+        return [(prefix, schema)], []
+    if is_object_schema(schema):
+        props = schema_properties(schema)
+        if len(props) == 0:
+            return [(prefix, schema)], []
+        opaque: list[tuple[PairingPath, Any]] = []
+        arrays: list[tuple[PairingPath, Any]] = []
+        for key, child in props.items():
+            child_opaque, child_arrays = _collect_pairing_fields(schema=child, prefix=(*prefix, key))
+            opaque.extend(child_opaque)
+            arrays.extend(child_arrays)
+        return opaque, arrays
+    return [(prefix, schema)], []
+
+
+def _item_pairing_fields(
+    *,
+    item_sch: Mapping[str, Any],
+    subfield_names: Sequence[str],
+) -> tuple[Sequence[PairingPath], Mapping[PairingPath, Any], Sequence[tuple[PairingPath, Any]]]:
+    opaque: list[tuple[PairingPath, Any]] = []
+    arrays: list[tuple[PairingPath, Any]] = []
+    for name in subfield_names:
+        child_opaque, child_arrays = _collect_pairing_fields(schema=item_sch.get(name, {}), prefix=(name,))
+        opaque.extend(child_opaque)
+        arrays.extend(child_arrays)
+    return [path for path, _ in opaque], dict(opaque), arrays
+
+
+def _flatten_pairing_rows(
+    rows: Sequence[Any],
+    *,
+    paths: Sequence[PairingPath],
+) -> Sequence[Mapping[PairingPath, Any]]:
+    return [{path: _read_segments(row, segments=path) for path in paths} for row in rows]
+
+
+def _fuzzy_for_paths(
+    paths: Sequence[PairingPath],
+    *,
+    fuzzy: Mapping[str, float],
+) -> Mapping[PairingPath, float]:
+    out: dict[PairingPath, float] = {}
+    for path in paths:
+        leaf = path[-1] if path else ""
+        if leaf in fuzzy:
+            out[path] = fuzzy[leaf]
+    return out
+
+
+def _value_leaf_count(
+    value: Any,
+    *,
+    schema: Any,
+) -> int:
+    """How many F1 leaves ``_count_subtree`` would emit for an unmatched value."""
+    if is_array_schema(schema):
+        if is_object_array_schema(schema):
+            item_sch = array_item_properties(schema)
+            names = array_subfield_names(schema)
+            total = 0
+            for row in as_rows(value):
+                rd = row if isinstance(row, Mapping) else {}
+                for name in names:
+                    total += _value_leaf_count(rd.get(name), schema=item_sch.get(name, {}))
+            return total
+        return 1
+    if is_object_schema(schema):
+        props = schema_properties(schema)
+        if len(props) == 0:
+            return 1
+        rd = value if isinstance(value, Mapping) else {}
+        return sum(_value_leaf_count(rd.get(key), schema=child) for key, child in props.items())
+    return 1
+
+
+def _row_leaf_count(
+    row: Any,
+    *,
+    item_sch: Mapping[str, Any],
+    names: Sequence[str],
+) -> int:
+    rd = row if isinstance(row, Mapping) else {}
+    return sum(_value_leaf_count(rd.get(name), schema=item_sch.get(name, {})) for name in names)
+
+
 def iou_xywh(a: BBox, b: BBox) -> float:
     ax, ay, aw, ah = a
     bx, by, bw, bh = b
+    if not all(map(math.isfinite, (ax, ay, aw, ah, bx, by, bw, bh))) or aw <= 0 or ah <= 0 or bw <= 0 or bh <= 0:
+        return 0.0
     ix = max(0.0, min(ax + aw, bx + bw) - max(ax, bx))
     iy = max(0.0, min(ay + ah, by + bh) - max(ay, by))
     inter = ix * iy
@@ -328,7 +485,9 @@ def iou_xywh(a: BBox, b: BBox) -> float:
         return 0.0
     # Reconstructing width as (x+w)-x is a few ulps off for values like 0.1,
     # so the raw ratio can exceed 1.0 even for identical boxes.
-    return min(1.0, inter / union)
+    # min(1.0, nan) is 1.0 in Python, so non-finite ratios must not clamp to a hit.
+    ratio = inter / union
+    return min(1.0, ratio) if math.isfinite(ratio) else 0.0
 
 
 class Scorer:
@@ -357,6 +516,148 @@ class Scorer:
         return configured_cell_match(
             expected, actual, field, fuzzy=self._fuzzy, normalizers=self._normalizers.get(gt_path)
         )
+
+    def _gold_needs_configured_match(
+        self,
+        *,
+        exp_rows: Sequence[Any],
+        pairing_paths: Sequence[PairingPath],
+        gt_field: str,
+    ) -> bool:
+        """True when this level's opaque pairing cells have a distinct alt or a normalizer.
+
+        Nested object-arrays detect this for themselves; do not inherit a parent flag.
+        """
+        if not pairing_paths or (not self._alt and not self._normalizers):
+            return False
+        for i, erow in enumerate(exp_rows):
+            for path in pairing_paths:
+                gt_path = f"{gt_field}[{i}].{_gt_rel_path(path)}"
+                if self._normalizers.get(gt_path):
+                    return True
+                alt = self._alt.get(gt_path)
+                if not alt:
+                    continue
+                canon = _read_segments(erow, segments=path)
+                if any(value != canon for value in alt):
+                    return True
+        return False
+
+    def _object_array_pair_cost(
+        self,
+        exp_val: Any,
+        act_val: Any,
+        *,
+        schema: Mapping[str, Any],
+        gt_path: str,
+    ) -> int:
+        """F1-aligned mismatch for one nested object-array under an already-paired parent."""
+        exp_rows = as_rows(exp_val)
+        act_rows = as_rows(act_val)
+        item_sch = array_item_properties(schema)
+        names = array_subfield_names(schema)
+        if len(names) == 0:
+            return 0
+        if len(exp_rows) == 0 or len(act_rows) == 0:
+            return sum(_row_leaf_count(row, item_sch=item_sch, names=names) for row in exp_rows) + sum(
+                _row_leaf_count(row, item_sch=item_sch, names=names) for row in act_rows
+            )
+        inner_paths, _, _ = _item_pairing_fields(item_sch=item_sch, subfield_names=names)
+        inner = self._pairing_cost_matrix(
+            act_rows,
+            exp_rows,
+            item_sch=item_sch,
+            subfield_names=names,
+            gt_field=gt_path,
+            use_alts=self._gold_needs_configured_match(exp_rows=exp_rows, pairing_paths=inner_paths, gt_field=gt_path),
+        )
+        row_ind, col_ind = linear_sum_assignment(inner)
+        paired = int(inner[row_ind, col_ind].sum())
+        matched_exp = {int(i) for i in col_ind}
+        matched_act = {int(j) for j in row_ind}
+        unmatched = sum(
+            _row_leaf_count(exp_rows[i], item_sch=item_sch, names=names)
+            for i in range(len(exp_rows))
+            if i not in matched_exp
+        ) + sum(
+            _row_leaf_count(act_rows[j], item_sch=item_sch, names=names)
+            for j in range(len(act_rows))
+            if j not in matched_act
+        )
+        return paired + unmatched
+
+    def _pairing_cost_matrix(
+        self,
+        act_rows: Sequence[Any],
+        exp_rows: Sequence[Any],
+        *,
+        item_sch: Mapping[str, Any],
+        subfield_names: Sequence[str],
+        gt_field: str,
+        use_alts: bool,
+    ) -> np.ndarray:
+        """``(n_actual, n_expected)`` leaf-mismatch cost, matching later F1 recursion.
+
+        Nested objects contribute each scored child (not one 0/1 dict compare).
+        Nested object-arrays add their own Hungarian leaf cost. Scalar arrays
+        stay one opaque cell.
+        """
+        paths, path_schemas, array_fields = _item_pairing_fields(item_sch=item_sch, subfield_names=subfield_names)
+        na, ne = len(act_rows), len(exp_rows)
+        path_fuzzy = _fuzzy_for_paths(paths, fuzzy=self._fuzzy)
+        if use_alts:
+            cost = np.zeros((na, ne), dtype=np.int32)
+            exp_cands: list[list[list[Any]]] = []
+            for i, erow in enumerate(exp_rows):
+                row_cands = []
+                for path in paths:
+                    canon = _read_segments(erow, segments=path)
+                    alt = self._alt.get(f"{gt_field}[{i}].{_gt_rel_path(path)}")
+                    cand = [canon]
+                    if alt:
+                        cand += [v for v in alt if v != canon and v not in cand]
+                    row_cands.append(cand)
+                exp_cands.append(row_cands)
+            for j, arow in enumerate(act_rows):
+                avals = [_read_segments(arow, segments=path) for path in paths]
+                for i, cands in enumerate(exp_cands):
+                    cost[j, i] = sum(
+                        not any(
+                            self._configured_cell_match(
+                                f"{gt_field}[{i}].{_gt_rel_path(paths[si])}",
+                                cv,
+                                avals[si],
+                                paths[si][-1] if paths[si] else "",
+                            )
+                            for cv in cands[si]
+                        )
+                        for si in range(len(paths))
+                    )
+        elif paths:
+            cost = mismatch_cost_matrix(
+                _flatten_pairing_rows(act_rows, paths=paths),
+                _flatten_pairing_rows(exp_rows, paths=paths),
+                subfields=paths,
+                fuzzy_field_thresholds=path_fuzzy,
+                field_schemas=path_schemas,
+            ).astype(np.int32, copy=False)
+        else:
+            cost = np.zeros((na, ne), dtype=np.int32)
+        if array_fields:
+            extra = np.zeros((na, ne), dtype=np.int32)
+            for j, arow in enumerate(act_rows):
+                for i, erow in enumerate(exp_rows):
+                    extra[j, i] = sum(
+                        self._object_array_pair_cost(
+                            _read_segments(erow, segments=path),
+                            _read_segments(arow, segments=path),
+                            schema=array_schema,
+                            gt_path=f"{gt_field}[{i}].{_gt_rel_path(path)}",
+                        )
+                        for path, array_schema in array_fields
+                    )
+            cost = cost + extra
+        return cost
 
     def _value_match(self, gt_path: str, canonical: Any, actual: Any, field: str) -> bool:
         """OR-acceptable: the prediction matches the expected value or any evidence value."""
@@ -415,11 +716,11 @@ class Scorer:
         return matched
 
     def _count_subtree(self, path: str, value: Any, schema: Mapping[str, Any], c: _Counts, *, expected: bool) -> None:
-        """Count an unmatched subtree's leaves on one side only (recall or precision miss).
+        """Count a one-sided subtree's leaves (recall-only or precision-only miss).
 
-        Unpaired rows must not go through ``_score_node``: that path treats a
-        missing partner as implicit ``null`` children and can *match* gold
-        nulls. There is no partner row here, so every leaf is a one-sided miss.
+        Used for unmatched rows and for a key present on only one side with no
+        schema ``default``. Do not route these through ``_score_node``: there is
+        no partner value, so every leaf is a miss.
         """
         if is_array_schema(schema):
             if is_object_array_schema(schema):
@@ -436,7 +737,8 @@ class Scorer:
                 rd = value if isinstance(value, Mapping) else {}
                 for key, child_schema in props.items():
                     child = f"{path}.{key}" if path else key
-                    self._count_subtree(child, rd.get(key), child_schema, c, expected=expected)
+                    in_side, child_val = lookup(rd, key, child_schema)
+                    self._count_subtree(child, child_val if in_side else None, child_schema, c, expected=expected)
                 return
         if expected:
             c.expected += 1
@@ -460,7 +762,9 @@ class Scorer:
         expected: bool,
     ) -> None:
         for s in nested_names:
-            self._count_subtree(f"{base}.{s}", row.get(s), item_sch.get(s, {}), c, expected=expected)
+            child_schema = item_sch.get(s, {})
+            in_side, child_val = lookup(row, s, child_schema)
+            self._count_subtree(f"{base}.{s}", child_val if in_side else None, child_schema, c, expected=expected)
 
     def _score_array(
         self, gt_field: str, pred_field: str, exp_rows: Any, act_rows: Any, schema: Mapping[str, Any], c: _Counts
@@ -551,68 +855,26 @@ class Scorer:
         # pair (and as one-sided misses for unmatched rows).
         match_for_exp: dict[int, int] = {}
         if len(exp_rows) > 0 and len(act_rows) > 0:
-            # Align on opaque + object cells; objects still count as one cost cell.
-            cost_names: Sequence[str] = cell_names + object_names
-            if len(cost_names) == 0:
-                cost_names = subfield_names
+            # Align on the same leaves F1 scores: opaque cells plus nested-object
+            # children (not a 0/1 ``==`` on the whole object). Object-arrays add
+            # their nested Hungarian cost. Scalar arrays stay one opaque cell.
+            pairing_paths, _, _ = _item_pairing_fields(item_sch=item_sch, subfield_names=subfield_names)
+            # Peel still keys original row dicts by schema column name (not nested
+            # segment tuples). Pairing-sensitive branches use pairing_paths.
+            cost_names: Sequence[str] = cell_names if cell_names else subfield_names
             fuzzy = self._fuzzy
-            exp_dicts = [e if isinstance(e, Mapping) else {} for e in exp_rows]
-            # The alt index holds every leaf's evidence value, so most entries
-            # equal the expected value. A genuinely different alternate expands
-            # the zero-cost graph; in that case use full assignment semantics and
-            # do not greedily peel canonical exact matches.
-            multi = False
-            for i, ed in enumerate(exp_dicts):
-                for s in cost_names:
-                    canon = ed.get(s)
-                    alt = self._alt.get(f"{gt_field}[{i}].{s}")
-                    if alt:
-                        seen = [canon]
-                        for value in alt:
-                            if value != canon and value not in seen:
-                                multi = True
-                                break
-                            seen.append(value)
-                    if multi:
-                        break
-                if multi:
-                    break
-
-            # Skipped when `multi` already forces the candidate path or no rule
-            # carries normalizers at all (the default): the path scan is
-            # O(rows x subfields) per array and would otherwise run for nothing.
-            has_normalizer = (
-                len(self._normalizers) > 0
-                and not multi
-                and any(self._normalizers.get(f"{gt_field}[{i}].{s}") for i in range(len(exp_rows)) for s in cost_names)
-            )
-
-            if multi or has_normalizer:
-                exp_cands = []
-                for i, ed in enumerate(exp_dicts):
-                    row_cands = []
-                    for s in cost_names:
-                        canon = ed.get(s)
-                        alt = self._alt.get(f"{gt_field}[{i}].{s}")
-                        cand = [canon]
-                        if alt:
-                            cand += [v for v in alt if v != canon and v not in cand]
-                        row_cands.append(cand)
-                    exp_cands.append(row_cands)
-                cost = np.empty((len(act_rows), len(exp_rows)), dtype=np.int16)
-                for j, arow in enumerate(act_rows):
-                    ad = arow if isinstance(arow, Mapping) else {}
-                    avals = [ad.get(s) for s in cost_names]
-                    for i, cands in enumerate(exp_cands):
-                        cost[j, i] = sum(
-                            not any(
-                                self._configured_cell_match(
-                                    f"{gt_field}[{i}].{cost_names[si]}", cv, avals[si], cost_names[si]
-                                )
-                                for cv in cands[si]
-                            )
-                            for si in range(len(cost_names))
-                        )
+            # Distinct alts / normalizers on *this* level's opaque cells expand the
+            # zero-cost graph, so skip the exact-row peel. Nested object-arrays
+            # detect configured match for themselves when they add their cost.
+            if self._gold_needs_configured_match(exp_rows=exp_rows, pairing_paths=pairing_paths, gt_field=gt_field):
+                cost = self._pairing_cost_matrix(
+                    act_rows,
+                    exp_rows,
+                    item_sch=item_sch,
+                    subfield_names=subfield_names,
+                    gt_field=gt_field,
+                    use_alts=True,
+                )
                 row_ind, col_ind = linear_sum_assignment(cost)
                 match_for_exp = {int(i): int(j) for j, i in zip(row_ind, col_ind, strict=True)}
             elif len(object_array_names) > 0 or len(object_names) > 0 or (has_ev_page and has_pred_page):
@@ -624,7 +886,14 @@ class Scorer:
                 # preserve the exact tie-break. ``has_ev_page``/``has_pred_page``
                 # are the bbox supersets, so this branch also covers every
                 # bbox-grounded array.
-                cost = mismatch_cost_matrix(act_rows, exp_rows, subfields=cost_names, fuzzy_field_thresholds=fuzzy)
+                cost = self._pairing_cost_matrix(
+                    act_rows,
+                    exp_rows,
+                    item_sch=item_sch,
+                    subfield_names=subfield_names,
+                    gt_field=gt_field,
+                    use_alts=False,
+                )
                 row_ind, col_ind = linear_sum_assignment(cost)
                 match_for_exp = {int(i): int(j) for j, i in zip(row_ind, col_ind, strict=True)}
             else:
@@ -684,8 +953,18 @@ class Scorer:
                         f"{gt_field}[{i}].{s}", f"{pred_field}[{mj}].{s}", ed.get(s), ad.get(s), item_sch.get(s, {}), c
                     )
                 for s in object_names:
-                    self._score_node(
-                        f"{gt_field}[{i}].{s}", f"{pred_field}[{mj}].{s}", ed.get(s), ad.get(s), item_sch.get(s, {}), c
+                    child_schema = item_sch.get(s, {})
+                    in_e, child_ev = lookup(ed, s, child_schema)
+                    in_a, child_av = lookup(ad, s, child_schema)
+                    self._score_pair(
+                        f"{gt_field}[{i}].{s}",
+                        f"{pred_field}[{mj}].{s}",
+                        in_e,
+                        child_ev,
+                        in_a,
+                        child_av,
+                        child_schema,
+                        c,
                     )
             else:  # unmatched GT row: cell subfields already counted; recurse nested as recall misses
                 self._count_unmatched_nested(
@@ -709,16 +988,45 @@ class Scorer:
             if self._pred_pages.get(pred_path):
                 c.p_claims += 1
         self._score_cell(gt_path, pred_path, ev, av, leaf, c)
-        # An omitted key is an implicit null prediction and always enters the
-        # precision denominator, right or wrong -- exactly as if the model had
-        # asserted null explicitly.
         c.predicted += 1
+
+    def _score_pair(
+        self,
+        gt_path: str,
+        pred_path: str,
+        in_e: bool,
+        ev: Any,
+        in_a: bool,
+        av: Any,
+        schema: Mapping[str, Any],
+        c: _Counts,
+    ) -> None:
+        # Presence after schema ``default``. The scorer itself is still chosen
+        # from ``schema`` in ``_score_node`` / ``_count_subtree``, not from
+        # whether ``ev``/``av`` is a list or dict.
+        if in_e and in_a:
+            self._score_node(gt_path, pred_path, ev, av, schema, c)
+        elif in_e:
+            self._count_subtree(gt_path, ev, schema, c, expected=True)
+        elif in_a:
+            self._count_subtree(pred_path, av, schema, c, expected=False)
+        # neither: no-op — do not treat "both missing" as a precision claim.
 
     def _score_node(
         self, gt_path: str, pred_path: str, ev: Any, av: Any, schema: Mapping[str, Any], c: _Counts
     ) -> None:
+        # Schema-only dispatch: gold/pred Python types do not select Hungarian
+        # vs object-walk vs scalar. ``as_rows`` / ``{}`` only coerce a mismatched
+        # instance once that scorer is already chosen.
         if is_array_schema(schema):
-            self._score_array(gt_path, pred_path, ev, av, schema, c)
+            # List-of-objects: Hungarian table. Array of primitives (string[] /
+            # number[] / …, incl. null combinators): one opaque cell, same as a
+            # string field. Empty items.properties is the primitive-array shape,
+            # not a skip — that used to drop nested lists like vendor.tags.
+            if is_object_array_schema(schema):
+                self._score_array(gt_path, pred_path, ev, av, schema, c)
+            else:
+                self._score_scalar_cell(gt_path, pred_path, ev, av, c)
             return
         if is_object_schema(schema):
             props = schema_properties(schema)
@@ -731,7 +1039,10 @@ class Scorer:
             for key in keys:
                 child_gt = f"{gt_path}.{key}" if gt_path else key
                 child_pred = f"{pred_path}.{key}" if pred_path else key
-                self._score_node(child_gt, child_pred, ed.get(key), ad.get(key), props[key], c)
+                child_schema = props.get(key, {})
+                in_e, child_ev = lookup(ed, key, child_schema)
+                in_a, child_av = lookup(ad, key, child_schema)
+                self._score_pair(child_gt, child_pred, in_e, child_ev, in_a, child_av, child_schema, c)
             return
         self._score_scalar_cell(gt_path, pred_path, ev, av, c)
 
@@ -739,8 +1050,16 @@ class Scorer:
         self, expected: Mapping[str, Any], actual: Mapping[str, Any], schema_props: Mapping[str, Any]
     ) -> _Counts:
         c = _Counts()
-        for name in sorted((set(expected) | set(actual)) - RESERVED_OUTPUT_KEYS):
-            self._score_node(name, name, expected.get(name), actual.get(name), schema_props.get(name, {}), c)
+        # Schema names first: a defaulted field omitted on both sides must still
+        # compare. Instance extras (keys not in the schema) stay in the union so
+        # a hallucinated key is still a scalar cell — shape of that cell is
+        # still schema (empty → opaque), not the Python type of the value.
+        names = (set(schema_props) | set(expected) | set(actual)) - RESERVED_OUTPUT_KEYS
+        for name in sorted(names):
+            schema = schema_props.get(name, {})
+            in_e, ev = lookup(expected, name, schema)
+            in_a, av = lookup(actual, name, schema)
+            self._score_pair(name, name, in_e, ev, in_a, av, schema, c)
         return c
 
 

--- a/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
+++ b/src/extract_bench/evaluation/metrics/extract/unified_evidence_metric.py
@@ -27,9 +27,11 @@ three additions:
    keyword is present; without ``default`` the key is absent (one-sided miss),
    not an implicit ``null``. ``lookup`` fills values; it does not pick the
    scorer. The same lookup is used at the root, inside nested objects, on
-   object columns of array rows after Hungarian pairing, and when reading
-   nested leaves for pairing cost. Opaque array cells stay ``array_record``'s
-   ``.get``. Row-pairing cost uses those same children (and nested
+   object columns of array rows after Hungarian pairing, on opaque array
+   cells, and when reading nested leaves for pairing cost. A missing key is
+   equal only to another missing key, unless ``default`` is present (then
+   missing also equals that default). Explicit ``0`` is never equal to
+   explicit ``null``. Row-pairing cost uses those same children (and nested
    object-arrays) so Hungarian maximizes the cells F1 actually scores.
    Scalar lists stay opaque.
 3. **Grounding (bbox + page).** Two parallel sets of counters, both value-gated
@@ -58,12 +60,12 @@ three additions:
    metric (excluded from the dataset average), rather than a 0.0 that would
    punish a document that simply cannot be graded for grounding.
 
-On a document with no object-array subfields, no object-valued cells, and no
-alternate evidence values, the ``*_value_*`` metrics are bit-identical to
-``array_record_*`` -- same alignment, subfields, cost matrix, and denominators
--- with no ``match_by`` rule anywhere. Object-array subfields and objects
-recursed as child cells
-make the value metrics diverge from array_record (per-child credit); the
+On a document with no object-array subfields, no object-valued cells, no
+alternate evidence values, and no omit/default split, the ``*_value_*``
+metrics match ``array_record_*`` alignment. ``array_record`` reads
+omitted keys with ``.get`` (implicit ``null``); this scorer uses ``lookup``.
+Object-array subfields and objects recursed as child cells make the value
+metrics diverge from array_record (per-child credit); the
 ``*_grounded_*`` metrics
 are the other new signal (0 for pipelines that emit no citations *on documents
 whose GT carries bboxes*; omitted entirely on documents whose GT has none).
@@ -350,6 +352,28 @@ def is_object_subfield(field_schema: Any) -> bool:
 type PairingPath = tuple[str, ...]
 
 
+class _Absent:
+    """Sentinel for a key that is missing and has no schema ``default``.
+
+    Distinct from JSON ``null`` so pairing can treat missing==missing and
+    missing!=null. A singleton so interned cost matrices hash it stably.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "ABSENT"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _Absent)
+
+    def __hash__(self) -> int:
+        return 0xAB5E11D
+
+
+ABSENT = _Absent()
+
+
 def _read_segments(
     row: Any,
     *,
@@ -360,9 +384,10 @@ def _read_segments(
 
     Keys are not split, so a schema field named ``a.b`` is one step, not two.
     Omitted keys use JSON Schema ``default`` when present, matching F1.
-    A missing key with no ``default`` stops the walk as ``None``. A present
-    non-object (including explicit ``null``) is coerced to ``{}`` before the
-    next step, the same way ``_score_node`` walks children.
+    A missing key with no ``default`` stops the walk as ``ABSENT``, not
+    ``None`` (explicit null). A present non-object (including explicit
+    ``null``) is coerced to ``{}`` before the next step, the same way
+    ``_score_node`` walks children.
     """
     cur: Any = row if isinstance(row, Mapping) else {}
     field_schema: Any = {}
@@ -376,7 +401,7 @@ def _read_segments(
             cur = {}
         present, cur = lookup(cur, part, field_schema)
         if not present:
-            return None
+            return ABSENT
     return cur
 
 
@@ -465,7 +490,10 @@ def _value_leaf_count(
             for row in as_rows(value):
                 rd = row if isinstance(row, Mapping) else {}
                 for name in names:
-                    total += _value_leaf_count(rd.get(name), schema=item_sch.get(name, {}))
+                    child_schema = item_sch.get(name, {})
+                    in_side, child_val = lookup(rd, name, child_schema)
+                    if in_side:
+                        total += _value_leaf_count(child_val, schema=child_schema)
             return total
         return 1
     if is_object_schema(schema):
@@ -473,7 +501,12 @@ def _value_leaf_count(
         if len(props) == 0:
             return 1
         rd = value if isinstance(value, Mapping) else {}
-        return sum(_value_leaf_count(rd.get(key), schema=child) for key, child in props.items())
+        total = 0
+        for key, child in props.items():
+            in_side, child_val = lookup(rd, key, child)
+            if in_side:
+                total += _value_leaf_count(child_val, schema=child)
+        return total
     return 1
 
 
@@ -484,7 +517,13 @@ def _row_leaf_count(
     names: Sequence[str],
 ) -> int:
     rd = row if isinstance(row, Mapping) else {}
-    return sum(_value_leaf_count(rd.get(name), schema=item_sch.get(name, {})) for name in names)
+    total = 0
+    for name in names:
+        child_schema = item_sch.get(name, {})
+        in_side, child_val = lookup(rd, name, child_schema)
+        if in_side:
+            total += _value_leaf_count(child_val, schema=child_schema)
+    return total
 
 
 def iou_xywh(a: BBox, b: BBox) -> float:
@@ -542,17 +581,18 @@ class Scorer:
     ) -> bool:
         """True when this level's opaque pairing cells have a distinct alt or a normalizer.
 
-        Nested object-arrays detect this for themselves; do not inherit a parent flag.
+        Nested object-arrays check their own leaves.
         """
-        if not pairing_paths or (not self._alt and not self._normalizers):
+        if len(pairing_paths) == 0 or (len(self._alt) == 0 and len(self._normalizers) == 0):
             return False
         for i, erow in enumerate(exp_rows):
             for path in pairing_paths:
                 gt_path = f"{gt_field}[{i}].{_gt_rel_path(path)}"
-                if self._normalizers.get(gt_path):
+                normalizers = self._normalizers.get(gt_path)
+                if normalizers is not None and len(normalizers) > 0:
                     return True
                 alt = self._alt.get(gt_path)
-                if not alt:
+                if alt is None or len(alt) == 0:
                     continue
                 canon = _read_segments(erow, segments=path, item_sch=item_sch)
                 if any(value != canon for value in alt):
@@ -717,11 +757,9 @@ class Scorer:
     ) -> bool:
         """Score one aligned cell (value + page + grounding). Caller owns the denominators.
 
-        ``ground=False`` scores value only, for cells in a giant array whose
-        grounding-family scoring was skipped (their g_expected/g_claims and
-        p_expected/p_claims were not counted either, so g_correct/p_correct must
-        not be counted here or the grounded/page precision/recall would be
-        computed against a truncated denominator).
+        ``ground=False`` scores value only: giant arrays skip grounding-family
+        counters (g_expected/g_claims and p_expected/p_claims), and this keeps
+        g_correct/p_correct on the same skipped set.
         """
         matched = self._value_match(gt_path, canonical, actual, field)
         if matched:
@@ -733,12 +771,14 @@ class Scorer:
                     c.p_correct += 1
         return matched
 
-    def _count_subtree(self, path: str, value: Any, schema: Mapping[str, Any], c: _Counts, *, expected: bool) -> None:
+    def _count_subtree(
+        self, path: str, value: Any, schema: Mapping[str, Any], c: _Counts, *, expected: bool, ground: bool = True
+    ) -> None:
         """Count a one-sided subtree's leaves (recall-only or precision-only miss).
 
-        Used for unmatched rows and for a key present on only one side with no
-        schema ``default``. Do not route these through ``_score_node``: there is
-        no partner value, so every leaf is a miss.
+        Unmatched rows and a key present on only one side have no partner, so
+        every leaf ``lookup`` reports present is a miss. Children ``lookup``
+        reports absent (no ``default``) are not cells.
         """
         if is_array_schema(schema):
             if is_object_array_schema(schema):
@@ -747,22 +787,30 @@ class Scorer:
                 for i, row in enumerate(as_rows(value)):
                     rd = row if isinstance(row, Mapping) else {}
                     for s in subfield_names:
-                        self._count_subtree(f"{path}[{i}].{s}", rd.get(s), item_sch.get(s, {}), c, expected=expected)
+                        child_schema = item_sch.get(s, {})
+                        in_side, child_val = lookup(rd, s, child_schema)
+                        if in_side:
+                            self._count_subtree(
+                                f"{path}[{i}].{s}", child_val, child_schema, c, expected=expected, ground=ground
+                            )
                 return
         elif is_object_schema(schema):
             props = schema_properties(schema)
             if len(props) > 0:
                 rd = value if isinstance(value, Mapping) else {}
                 for key, child_schema in props.items():
-                    child = f"{path}.{key}" if path else key
+                    child = f"{path}.{key}" if len(path) > 0 else key
                     in_side, child_val = lookup(rd, key, child_schema)
-                    self._count_subtree(child, child_val if in_side else None, child_schema, c, expected=expected)
+                    if in_side:
+                        self._count_subtree(child, child_val, child_schema, c, expected=expected, ground=ground)
                 return
         if expected:
             c.expected += 1
-            self._note_grounded_expected(path, c)
-            if self._ev_pages.get(path):
-                c.p_expected += 1
+            if ground:
+                self._note_grounded_expected(path, c)
+                pages = self._ev_pages.get(path)
+                if pages is not None and len(pages) > 0:
+                    c.p_expected += 1
         else:
             # Extra predicted subtree: no GT counterpart exists, so its citation
             # bboxes are ungradeable and do not enter the grounded precision
@@ -778,14 +826,24 @@ class Scorer:
         c: _Counts,
         *,
         expected: bool,
+        ground: bool = True,
     ) -> None:
         for s in nested_names:
             child_schema = item_sch.get(s, {})
             in_side, child_val = lookup(row, s, child_schema)
-            self._count_subtree(f"{base}.{s}", child_val if in_side else None, child_schema, c, expected=expected)
+            if in_side:
+                self._count_subtree(f"{base}.{s}", child_val, child_schema, c, expected=expected, ground=ground)
 
     def _score_array(
-        self, gt_field: str, pred_field: str, exp_rows: Any, act_rows: Any, schema: Mapping[str, Any], c: _Counts
+        self,
+        gt_field: str,
+        pred_field: str,
+        exp_rows: Any,
+        act_rows: Any,
+        schema: Mapping[str, Any],
+        c: _Counts,
+        *,
+        ground: bool = True,
     ) -> None:
         # gt_field / pred_field are separate base paths: ground-truth cells (alt
         # values, evidence boxes) key off gt_field; predicted cells (citations)
@@ -805,10 +863,8 @@ class Scorer:
             s for s in subfield_names if s not in object_array_names and is_object_subfield(item_sch.get(s, {}))
         ]
         cell_names = [s for s in subfield_names if s not in object_array_names and s not in object_names]
-        # Opaque-cell denominators: array_record-exact (rows x cell subfields).
-        # Object and object-array fields are counted by the recursion below.
-        c.expected += len(exp_rows) * len(cell_names)
-        c.predicted += len(act_rows) * len(cell_names)
+        # Opaque, object, and object-array cells are counted via ``lookup`` /
+        # ``_score_pair`` below (omit with no ``default`` is not a cell).
         c.expected_rows += len(exp_rows)
         c.predicted_rows += len(act_rows)
         # A flat array whose full grounded matrix would be multi-GB: skip its
@@ -817,7 +873,8 @@ class Scorer:
         # (value-identical for opaque cells), and not counting
         # g_expected/g_claims/p_expected/p_claims here keeps the grounded and
         # page denominators consistent with the skipped g_correct/p_correct.
-        # ``not object_array_names and not object_names`` guarantees no nested recursion, so the peel cannot
+        # ``len(object_array_names) == 0 and len(object_names) == 0`` guarantees
+        # no nested recursion, so the peel cannot
         # shift nested TP. The memory win only lands on the plain peel path: an
         # array with genuine alternate values (``multi``) or field normalizers
         # still builds the full candidate matrix below regardless of ``giant`` --
@@ -833,6 +890,7 @@ class Scorer:
             and len(object_names) == 0
             and len(exp_rows) * len(act_rows) > _GROUNDED_MAX_CELLS
         )
+        score_ground = ground and not giant
         # Page presence drives both the grounded-family denominators and the
         # pairing-sensitive branch selection below. It is a SUPERSET of bbox
         # presence (every bbox-bearing evidence/citation also carries a page), so
@@ -844,19 +902,36 @@ class Scorer:
             # grounding-family scoring was actually dropped -- only then is the
             # document's grounded/page score incomplete and must be withheld
             # entirely. Pages are the superset, so this covers dropped bboxes too.
-            dropped_grounding = any(
-                self._ev_pages.get(f"{gt_field}[{i}].{s}") for i in range(len(exp_rows)) for s in cell_names
-            ) or any(self._pred_pages.get(f"{pred_field}[{j}].{s}") for j in range(len(act_rows)) for s in cell_names)
+            dropped_grounding = False
+            for i in range(len(exp_rows)):
+                for s in cell_names:
+                    pages = self._ev_pages.get(f"{gt_field}[{i}].{s}")
+                    if pages is not None and len(pages) > 0:
+                        dropped_grounding = True
+                        break
+                if dropped_grounding:
+                    break
+            if not dropped_grounding:
+                for j in range(len(act_rows)):
+                    for s in cell_names:
+                        pages = self._pred_pages.get(f"{pred_field}[{j}].{s}")
+                        if pages is not None and len(pages) > 0:
+                            dropped_grounding = True
+                            break
+                    if dropped_grounding:
+                        break
             if dropped_grounding:
                 c.grounded_incomplete = True
         else:
             for i in range(len(exp_rows)):
                 for s in cell_names:
                     gt_path = f"{gt_field}[{i}].{s}"
-                    self._note_grounded_expected(gt_path, c)
-                    if self._ev_pages.get(gt_path):
-                        c.p_expected += 1
+                    pages = self._ev_pages.get(gt_path)
+                    if pages is not None and len(pages) > 0:
                         has_ev_page = True
+                        break
+                if has_ev_page:
+                    break
             # Flag-only scan: g_claims/p_claims are counted per aligned pair
             # below, and only for cells whose GT side carries a bbox/page
             # (ungradeable claims stay out of the precision denominator). The flag
@@ -864,7 +939,8 @@ class Scorer:
             # the pairing-sensitive branch selection below covers both families.
             for j in range(len(act_rows)):
                 for s in cell_names:
-                    if self._pred_pages.get(f"{pred_field}[{j}].{s}"):
+                    pages = self._pred_pages.get(f"{pred_field}[{j}].{s}")
+                    if pages is not None and len(pages) > 0:
                         has_pred_page = True
                         break
                 if has_pred_page:
@@ -876,11 +952,8 @@ class Scorer:
             # Align on the same leaves F1 scores: opaque cells plus nested-object
             # children (not a 0/1 ``==`` on the whole object). Object-arrays add
             # their nested Hungarian cost. Scalar arrays stay one opaque cell.
-            pairing_paths, _, _ = _item_pairing_fields(item_sch=item_sch, subfield_names=subfield_names)
-            # Peel still keys original row dicts by schema column name (not nested
-            # segment tuples). Pairing-sensitive branches use pairing_paths.
-            cost_names: Sequence[str] = cell_names if cell_names else subfield_names
-            fuzzy = self._fuzzy
+            pairing_paths, path_schemas, _ = _item_pairing_fields(item_sch=item_sch, subfield_names=subfield_names)
+            path_fuzzy = _fuzzy_for_paths(pairing_paths, fuzzy=self._fuzzy)
             # Distinct alts / normalizers on *this* level's opaque cells expand the
             # zero-cost graph, so skip the exact-row peel. Nested object-arrays
             # detect configured match for themselves when they add their cost.
@@ -919,14 +992,20 @@ class Scorer:
             else:
                 # Opaque-cell-only, un-grounded: the value score is pairing-
                 # independent (n_pairs*k - total_cost), so peeling exact rows is
-                # safe. Reuse the vectorized interned matrix on the residual rows.
+                # safe. Flatten through ``lookup`` so omit/default/null match F1.
+                flat_act = list(_flatten_pairing_rows(act_rows, paths=pairing_paths, item_sch=item_sch))
+                flat_exp = list(_flatten_pairing_rows(exp_rows, paths=pairing_paths, item_sch=item_sch))
                 assignment = peel_exact_row_matches(
-                    act_rows, exp_rows, subfields=cost_names, fuzzy_field_thresholds=fuzzy
+                    flat_act,
+                    flat_exp,
+                    subfields=pairing_paths,
+                    fuzzy_field_thresholds=path_fuzzy,
+                    field_schemas=path_schemas,
                 )
                 match_for_exp = {int(i): int(j) for j, i in assignment.pairs}
                 if len(assignment.unmatched_actual_indices) > 0 and len(assignment.unmatched_expected_indices) > 0:
-                    residual_actual = [act_rows[idx] for idx in assignment.unmatched_actual_indices]
-                    residual_expected = [exp_rows[idx] for idx in assignment.unmatched_expected_indices]
+                    residual_actual = [flat_act[idx] for idx in assignment.unmatched_actual_indices]
+                    residual_expected = [flat_exp[idx] for idx in assignment.unmatched_expected_indices]
                     # Memory ceiling on the residual assignment matrix (parallel to
                     # the _GROUNDED_MAX_CELLS grounding guard above). After the
                     # exact-row peel, a flat array whose prediction diverges leaves
@@ -942,8 +1021,9 @@ class Scorer:
                         cost = mismatch_cost_matrix(
                             residual_actual,
                             residual_expected,
-                            subfields=cost_names,
-                            fuzzy_field_thresholds=fuzzy,
+                            subfields=pairing_paths,
+                            fuzzy_field_thresholds=path_fuzzy,
+                            field_schemas=path_schemas,
                         )
                         row_ind, col_ind = linear_sum_assignment(cost)
                         match_for_exp.update(
@@ -960,19 +1040,7 @@ class Scorer:
             mj = match_for_exp.get(i)
             if mj is not None:
                 ad = act_rows[mj] if isinstance(act_rows[mj], Mapping) else {}
-                for s in cell_names:
-                    gt_path = f"{gt_field}[{i}].{s}"
-                    pred_path = f"{pred_field}[{mj}].{s}"
-                    if not giant:
-                        self._note_grounded_claim(gt_path, pred_path, c)
-                        if self._ev_pages.get(gt_path) and self._pred_pages.get(pred_path):
-                            c.p_claims += 1
-                    self._score_cell(gt_path, pred_path, ed.get(s), ad.get(s), s, c, ground=not giant)
-                for s in object_array_names:  # recurse with the matched predicted index, not the GT index
-                    self._score_array(
-                        f"{gt_field}[{i}].{s}", f"{pred_field}[{mj}].{s}", ed.get(s), ad.get(s), item_sch.get(s, {}), c
-                    )
-                for s in object_names:
+                for s in subfield_names:
                     child_schema = item_sch.get(s, {})
                     in_e, child_ev = lookup(ed, s, child_schema)
                     in_a, child_av = lookup(ad, s, child_schema)
@@ -985,29 +1053,47 @@ class Scorer:
                         child_av,
                         child_schema,
                         c,
+                        ground=score_ground,
                     )
-            else:  # unmatched GT row: cell subfields already counted; recurse nested as recall misses
+            else:
                 self._count_unmatched_nested(
-                    f"{gt_field}[{i}]", ed, item_sch, object_array_names + object_names, c, expected=True
+                    f"{gt_field}[{i}]",
+                    ed,
+                    item_sch,
+                    subfield_names,
+                    c,
+                    expected=True,
+                    ground=score_ground,
                 )
-        for j, arow in enumerate(act_rows):  # extra predicted rows: nested fields are precision misses
+        for j, arow in enumerate(act_rows):
             if j in matched_act:
                 continue
             ad = arow if isinstance(arow, Mapping) else {}
             self._count_unmatched_nested(
-                f"{pred_field}[{j}]", ad, item_sch, object_array_names + object_names, c, expected=False
+                f"{pred_field}[{j}]",
+                ad,
+                item_sch,
+                subfield_names,
+                c,
+                expected=False,
+                ground=score_ground,
             )
 
-    def _score_scalar_cell(self, gt_path: str, pred_path: str, ev: Any, av: Any, c: _Counts) -> None:
+    def _score_scalar_cell(
+        self, gt_path: str, pred_path: str, ev: Any, av: Any, c: _Counts, *, ground: bool = True
+    ) -> None:
         leaf = path_leaf(gt_path)
         c.expected += 1
-        self._note_grounded_expected(gt_path, c)
-        self._note_grounded_claim(gt_path, pred_path, c)
-        if self._ev_pages.get(gt_path):
-            c.p_expected += 1
-            if self._pred_pages.get(pred_path):
-                c.p_claims += 1
-        self._score_cell(gt_path, pred_path, ev, av, leaf, c)
+        if ground:
+            self._note_grounded_expected(gt_path, c)
+            self._note_grounded_claim(gt_path, pred_path, c)
+            ev_pages = self._ev_pages.get(gt_path)
+            if ev_pages is not None and len(ev_pages) > 0:
+                c.p_expected += 1
+                pred_pages = self._pred_pages.get(pred_path)
+                if pred_pages is not None and len(pred_pages) > 0:
+                    c.p_claims += 1
+        self._score_cell(gt_path, pred_path, ev, av, leaf, c, ground=ground)
         c.predicted += 1
 
     def _score_pair(
@@ -1020,33 +1106,41 @@ class Scorer:
         av: Any,
         schema: Mapping[str, Any],
         c: _Counts,
+        *,
+        ground: bool = True,
     ) -> None:
-        # Presence after schema ``default``. The scorer itself is still chosen
-        # from ``schema`` in ``_score_node`` / ``_count_subtree``, not from
-        # whether ``ev``/``av`` is a list or dict.
+        # ``in_e``/``in_a`` are ``lookup`` presence (schema ``default`` already
+        # applied). ``_score_node`` / ``_count_subtree`` pick the scorer from
+        # ``schema``.
         if in_e and in_a:
-            self._score_node(gt_path, pred_path, ev, av, schema, c)
+            self._score_node(gt_path, pred_path, ev, av, schema, c, ground=ground)
         elif in_e:
-            self._count_subtree(gt_path, ev, schema, c, expected=True)
+            self._count_subtree(gt_path, ev, schema, c, expected=True, ground=ground)
         elif in_a:
-            self._count_subtree(pred_path, av, schema, c, expected=False)
-        # neither: no-op — do not treat "both missing" as a precision claim.
+            self._count_subtree(pred_path, av, schema, c, expected=False, ground=ground)
+        # neither: both absent is not a cell.
 
     def _score_node(
-        self, gt_path: str, pred_path: str, ev: Any, av: Any, schema: Mapping[str, Any], c: _Counts
+        self,
+        gt_path: str,
+        pred_path: str,
+        ev: Any,
+        av: Any,
+        schema: Mapping[str, Any],
+        c: _Counts,
+        *,
+        ground: bool = True,
     ) -> None:
-        # Schema-only dispatch: gold/pred Python types do not select Hungarian
-        # vs object-walk vs scalar. ``as_rows`` / ``{}`` only coerce a mismatched
-        # instance once that scorer is already chosen.
+        # Schema type chooses Hungarian vs object-walk vs scalar. ``as_rows`` /
+        # ``{}`` coerce a mismatched instance after that choice.
         if is_array_schema(schema):
-            # List-of-objects: Hungarian table. Array of primitives (string[] /
-            # number[] / …, incl. null combinators): one opaque cell, same as a
-            # string field. Empty items.properties is the primitive-array shape,
-            # not a skip — that used to drop nested lists like vendor.tags.
+            # List-of-objects: Hungarian table. Primitive arrays (string[] /
+            # number[] / …, including null combinators and empty
+            # items.properties) are one opaque cell, the same as a string field.
             if is_object_array_schema(schema):
-                self._score_array(gt_path, pred_path, ev, av, schema, c)
+                self._score_array(gt_path, pred_path, ev, av, schema, c, ground=ground)
             else:
-                self._score_scalar_cell(gt_path, pred_path, ev, av, c)
+                self._score_scalar_cell(gt_path, pred_path, ev, av, c, ground=ground)
             return
         if is_object_schema(schema):
             props = schema_properties(schema)
@@ -1054,17 +1148,17 @@ class Scorer:
             ad = av if isinstance(av, Mapping) else {}
             keys = list(props.keys())
             if len(keys) == 0:
-                self._score_scalar_cell(gt_path, pred_path, ev, av, c)
+                self._score_scalar_cell(gt_path, pred_path, ev, av, c, ground=ground)
                 return
             for key in keys:
-                child_gt = f"{gt_path}.{key}" if gt_path else key
-                child_pred = f"{pred_path}.{key}" if pred_path else key
+                child_gt = f"{gt_path}.{key}" if len(gt_path) > 0 else key
+                child_pred = f"{pred_path}.{key}" if len(pred_path) > 0 else key
                 child_schema = props.get(key, {})
                 in_e, child_ev = lookup(ed, key, child_schema)
                 in_a, child_av = lookup(ad, key, child_schema)
-                self._score_pair(child_gt, child_pred, in_e, child_ev, in_a, child_av, child_schema, c)
+                self._score_pair(child_gt, child_pred, in_e, child_ev, in_a, child_av, child_schema, c, ground=ground)
             return
-        self._score_scalar_cell(gt_path, pred_path, ev, av, c)
+        self._score_scalar_cell(gt_path, pred_path, ev, av, c, ground=ground)
 
     def score_root(
         self, expected: Mapping[str, Any], actual: Mapping[str, Any], schema_props: Mapping[str, Any]

--- a/tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py
@@ -275,6 +275,14 @@ def test_array_record_match_keeps_punctuation_spacing_significant_by_default() -
     assert cell_match("R. L.\nUnderwood", "R. L. Underwood", "operator", fuzzy_field_thresholds=fuzzy)
 
 
+def test_cell_match_zero_is_not_null() -> None:
+    fuzzy: dict[str, float] = {}
+    assert cell_match(0, None, "n", fuzzy_field_thresholds=fuzzy) is False
+    assert cell_match(None, 0, "n", fuzzy_field_thresholds=fuzzy) is False
+    assert cell_match(0, 0, "n", fuzzy_field_thresholds=fuzzy) is True
+    assert cell_match(None, None, "n", fuzzy_field_thresholds=fuzzy) is True
+
+
 def test_array_record_match_date_normalization_can_be_disabled() -> None:
     actual = {
         "account": "1234",

--- a/tests/extract_bench/evaluation/metrics/extract/test_json_subset_match.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_json_subset_match.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from extract_bench.evaluation.metrics.extract.json_subset_match import (
+    _is_nullable_numeric_field,
+    json_subset_match_score,
+)
+
+_NULLABLE_NUMERIC_SCHEMA: dict[str, Any] = {
+    "anyOf": [{"type": "number"}, {"type": "null"}],
+    "default": None,
+}
+_NULLABLE_NUMERIC_TYPE_LIST: dict[str, Any] = {"type": ["number", "null"]}
+_PLAIN_NUMERIC_SCHEMA: dict[str, Any] = {"type": "number"}
+
+
+def _wrap_schema_with_numeric_field(field_schema: Mapping[str, Any]) -> dict[str, Any]:
+    return {"type": "object", "properties": {"amount": field_schema}}
+
+
+def test_is_nullable_numeric_field_recognizes_anyof_shape() -> None:
+    assert _is_nullable_numeric_field(_NULLABLE_NUMERIC_SCHEMA) is True
+    assert _is_nullable_numeric_field({"anyOf": [{"type": "null"}, {"type": "number"}]}) is True
+    assert _is_nullable_numeric_field(_NULLABLE_NUMERIC_TYPE_LIST) is True
+    assert _is_nullable_numeric_field({"type": ["null", "number"]}) is True
+
+
+def test_is_nullable_numeric_field_rejects_other_shapes() -> None:
+    assert _is_nullable_numeric_field(_PLAIN_NUMERIC_SCHEMA) is False
+    assert _is_nullable_numeric_field({"anyOf": [{"type": "string"}, {"type": "null"}]}) is False
+    assert _is_nullable_numeric_field({"type": ["number", "null", "string"]}) is False
+    assert _is_nullable_numeric_field({"anyOf": [{"type": "number"}, {"type": "null"}, {"type": "string"}]}) is False
+    assert _is_nullable_numeric_field(None) is False
+    assert _is_nullable_numeric_field({}) is False
+
+
+def test_null_equals_zero_on_nullable_numeric() -> None:
+    schema = _wrap_schema_with_numeric_field(_NULLABLE_NUMERIC_SCHEMA)
+    assert json_subset_match_score(expected={"amount": None}, actual={"amount": 0.0}, data_schema=schema) == 1.0
+    assert json_subset_match_score(expected={"amount": 0.0}, actual={"amount": None}, data_schema=schema) == 1.0
+    assert json_subset_match_score(expected={"amount": None}, actual={"amount": 0}, data_schema=schema) == 1.0
+    schema_type_list = _wrap_schema_with_numeric_field(_NULLABLE_NUMERIC_TYPE_LIST)
+    assert (
+        json_subset_match_score(expected={"amount": None}, actual={"amount": 0.0}, data_schema=schema_type_list) == 1.0
+    )
+
+
+def test_null_not_equals_zero_on_non_nullable_numeric() -> None:
+    schema = _wrap_schema_with_numeric_field(_PLAIN_NUMERIC_SCHEMA)
+    assert json_subset_match_score(expected={"amount": None}, actual={"amount": 0.0}, data_schema=schema) == 0.0
+
+
+def test_nonzero_still_mismatches_on_nullable_numeric() -> None:
+    schema = _wrap_schema_with_numeric_field(_NULLABLE_NUMERIC_SCHEMA)
+    assert json_subset_match_score(expected={"amount": None}, actual={"amount": 1.5}, data_schema=schema) == 0.0
+
+
+def test_no_schema_falls_back_to_strict_equality() -> None:
+    assert json_subset_match_score(expected={"amount": None}, actual={"amount": 0.0}) == 0.0

--- a/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
@@ -807,6 +807,99 @@ def test_hungarian_pairing_fills_omitted_nested_defaults() -> None:
     assert _val(uni, "extract_unified_value_precision") == 1.0
 
 
+def test_hungarian_pairs_zero_and_null_as_distinct_cells() -> None:
+    """Reversed rows that differ only by 0 vs null pair on those values.
+
+    List-order pairing misses both numeric cells (2/4). Crossing matches 0 to 0
+    and null to null (4/4).
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "k": {"type": ["string", "null"]},
+                        "n": {"type": ["number", "null"]},
+                    },
+                },
+            }
+        },
+    }
+    expected = {"rows": [{"k": "a", "n": 0}, {"k": "a", "n": None}]}
+    actual = {"rows": [{"k": "a", "n": None}, {"k": "a", "n": 0}]}
+    uni = compute_unified_evidence_metrics(expected, actual, [], [], schema)
+    assert _val(uni, "extract_unified_value_f1") == 1.0
+
+
+def test_hungarian_pairs_omitted_nested_key_as_distinct_from_null() -> None:
+    """Same class, nested objects that differ in which child is explicit null.
+
+    Crossing: null matches null, absent matches absent. List order treats each
+    explicit null as a one-sided miss against the other child's omit.
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "cls": {"type": ["string", "null"]},
+                        "obj": {
+                            "type": "object",
+                            "properties": {
+                                "a": {"type": ["string", "null"]},
+                                "b": {"type": ["string", "null"]},
+                            },
+                        },
+                    },
+                },
+            }
+        },
+    }
+    expected = {
+        "rows": [
+            {"cls": "x", "obj": {"a": None}},
+            {"cls": "x", "obj": {"b": None}},
+        ]
+    }
+    actual = {
+        "rows": [
+            {"cls": "x", "obj": {"b": None}},
+            {"cls": "x", "obj": {"a": None}},
+        ]
+    }
+    uni = compute_unified_evidence_metrics(expected, actual, [], [], schema)
+    assert _val(uni, "extract_unified_value_f1") == 1.0
+
+
+def test_hungarian_pairs_omitted_default_with_explicit_default_on_array_columns() -> None:
+    """Omit with ``default: 0`` pairs with an explicit 0 on a reversed row."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "k": {"type": ["string", "null"]},
+                        "n": {"type": ["number", "null"], "default": 0},
+                    },
+                },
+            }
+        },
+    }
+    expected = {"rows": [{"k": "x"}, {"k": "x", "n": 1}]}
+    actual = {"rows": [{"k": "x", "n": 1}, {"k": "x", "n": 0}]}
+    uni = compute_unified_evidence_metrics(expected, actual, [], [], schema)
+    assert _val(uni, "extract_unified_value_f1") == 1.0
+
+
 def test_pairing_walks_schema_keys_that_contain_dots() -> None:
     """A key named ``a.b`` is one field, not a nested ``a`` then ``b``.
 
@@ -1278,9 +1371,9 @@ _NESTED_PEEL_SCHEMA: dict[str, Any] = {
 }
 
 
-def _spy_on_peel(monkeypatch: Any) -> list[list[str]]:
+def _spy_on_peel(monkeypatch: Any) -> list[list[Any]]:
     """Record the cost-subfields each exact-row peel call aligned on."""
-    calls: list[list[str]] = []
+    calls: list[list[Any]] = []
     original = unified_evidence_metric.peel_exact_row_matches
 
     def _spy(
@@ -1308,7 +1401,7 @@ def test_exact_peel_used_for_flat_ungrounded_arrays(monkeypatch: Any) -> None:
     calls = _spy_on_peel(monkeypatch)
     rows = [{"id": "1", "value": "a"}, {"id": "2", "value": "b"}]
     compute_unified_evidence_metrics({"rows": rows}, {"rows": rows}, [], [], _FLAT_PEEL_SCHEMA)
-    assert ["id", "value"] in calls, "flat un-grounded arrays must keep the fast exact-row peel"
+    assert [("id",), ("value",)] in calls, "flat un-grounded arrays take the exact-row peel"
 
 
 def test_exact_peel_skipped_for_object_array_subfields(monkeypatch: Any) -> None:
@@ -1316,10 +1409,10 @@ def test_exact_peel_skipped_for_object_array_subfields(monkeypatch: Any) -> None
     rows = [{"id": "A", "kids": [{"v": "x"}]}, {"id": "B", "kids": [{"v": "y"}]}]
     compute_unified_evidence_metrics({"rows": rows}, {"rows": rows}, [], [], _NESTED_PEEL_SCHEMA)
     # The outer array (identity cell "id") has a nested object array, so its
-    # alignment must use full assignment -- the peel must not see ["id"].
-    assert ["id"] not in calls, "outer array with object-array subfields must use full assignment"
-    # The inner flat "kids" arrays are opaque-cell-only, so they still peel.
-    assert ["v"] in calls, "flat inner sub-arrays should still use the fast peel"
+    # alignment uses full assignment -- the peel does not see [("id",)].
+    assert [("id",)] not in calls, "outer array with object-array subfields uses full assignment"
+    # The inner flat "kids" arrays are opaque-cell-only, so they peel.
+    assert [("v",)] in calls, "flat inner sub-arrays take the exact-row peel"
 
 
 def test_exact_peel_skipped_when_cell_grounding_present(monkeypatch: Any) -> None:
@@ -1683,6 +1776,105 @@ def test_in_row_object_child_omit_uses_schema_default() -> None:
     assert _val(uni, "extract_unified_value_precision") == 1.0
 
 
+def test_omitted_number_equals_zero_only_with_schema_default() -> None:
+    with_default = {
+        "type": "object",
+        "properties": {"n": {"type": ["number", "null"], "default": 0}},
+    }
+    without_default = {
+        "type": "object",
+        "properties": {"n": {"type": ["number", "null"]}},
+    }
+    rules = [_rule("n", 0)]
+    match = compute_unified_evidence_metrics({"n": 0}, {}, rules, [], with_default)
+    assert _val(match, "extract_unified_value_f1") == 1.0
+    miss = compute_unified_evidence_metrics({"n": 0}, {}, rules, [], without_default)
+    miss_meta = next(m.metadata for m in miss if m.metric_name == "extract_unified_value_recall")
+    assert miss_meta["expected_cells"] == 1
+    assert miss_meta["predicted_cells"] == 0
+    assert _val(miss, "extract_unified_value_recall") == 0.0
+    explicit_null = compute_unified_evidence_metrics({"n": 0}, {"n": None}, rules, [], with_default)
+    assert _val(explicit_null, "extract_unified_value_f1") == 0.0
+
+
+def test_array_row_omit_matches_object_lookup_rules() -> None:
+    """Schema-typed array item properties use the same lookup as objects."""
+    name_schema = {"type": ["string", "null"]}
+    object_schema = {"type": "object", "properties": {"name": name_schema}}
+    array_schema = {
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {"type": "object", "properties": {"name": name_schema}},
+            }
+        },
+    }
+    obj = compute_unified_evidence_metrics({"name": None}, {}, [_rule("name", None)], [], object_schema)
+    arr = compute_unified_evidence_metrics(
+        {"rows": [{"name": None}]}, {"rows": [{}]}, [_rule("rows[0].name", None)], [], array_schema
+    )
+    obj_meta = next(m.metadata for m in obj if m.metric_name == "extract_unified_value_recall")
+    arr_meta = next(m.metadata for m in arr if m.metric_name == "extract_unified_value_recall")
+    assert obj_meta["expected_cells"] == 1
+    assert arr_meta["expected_cells"] == 1
+    assert obj_meta["predicted_cells"] == 0
+    assert arr_meta["predicted_cells"] == 0
+    assert _val(obj, "extract_unified_value_f1") == _val(arr, "extract_unified_value_f1")
+
+    name_default = {"type": ["string", "null"], "default": None}
+    object_default = {"type": "object", "properties": {"name": name_default}}
+    array_default = {
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {"type": "object", "properties": {"name": name_default}},
+            }
+        },
+    }
+    obj_d = compute_unified_evidence_metrics({"name": None}, {}, [_rule("name", None)], [], object_default)
+    arr_d = compute_unified_evidence_metrics(
+        {"rows": [{"name": None}]}, {"rows": [{}]}, [_rule("rows[0].name", None)], [], array_default
+    )
+    assert _val(obj_d, "extract_unified_value_f1") == 1.0
+    assert _val(arr_d, "extract_unified_value_f1") == 1.0
+
+
+def test_one_sided_object_miss_skips_unasserted_schema_children() -> None:
+    """Gold never asserted ``tags``, so a missing vendor does not emit that cell."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "vendor": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "tags": {"type": "array", "items": {"type": ["string", "null"]}},
+                },
+            }
+        },
+    }
+    gold_name = {"vendor": {"name": "Acme"}}
+    pred: dict[str, Any] = {}
+    name_only = compute_unified_evidence_metrics(gold_name, pred, [_rule("vendor.name", "Acme")], [], schema)
+    empty_vendor = compute_unified_evidence_metrics({"vendor": {}}, pred, [], [], schema)
+    name_meta = next(m.metadata for m in name_only if m.metric_name == "extract_unified_value_recall")
+    assert name_meta["expected_cells"] == 1
+    assert name_meta["predicted_cells"] == 0
+    assert empty_vendor == []
+    both_asserted = compute_unified_evidence_metrics(
+        {"vendor": {"name": "Acme", "tags": ["x"]}},
+        pred,
+        [_rule("vendor.name", "Acme"), _rule("vendor.tags", ["x"])],
+        [],
+        schema,
+    )
+    both_meta = next(m.metadata for m in both_asserted if m.metric_name == "extract_unified_value_recall")
+    assert both_meta["expected_cells"] == 2
+    assert both_meta["predicted_cells"] == 0
+
+
 def test_supported_normalizers_match_schema_vocabulary() -> None:
     from extract_bench.test_cases.schema import EXTRACT_FIELD_NORMALIZERS
 
@@ -1722,7 +1914,7 @@ def test_giant_grounded_array_skips_grounding_value_exact_and_peels(monkeypatch:
     calls = _spy_on_peel(monkeypatch)
     skipped = compute_unified_evidence_metrics(expected, actual, rules, cits, _schema())
 
-    assert ["security", "coupon", "note"] in calls, "giant grounded array must fall back to the peel"
+    assert [("security",), ("coupon",), ("note",)] in calls, "giant grounded array falls back to the peel"
     # Value metrics identical to the full-matrix reference.
     for name in (
         "extract_unified_value_precision",

--- a/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
@@ -13,6 +13,7 @@ from extract_bench.evaluation.metrics.extract.unified_evidence_metric import (
     compute_unified_evidence_metrics,
     index_citations,
     iou_xywh,
+    lookup,
     path_leaf,
 )
 from extract_bench.test_cases.schema import ExtractFieldTestRule, FieldEvidence
@@ -327,15 +328,49 @@ def test_omitted_object_is_null_children_not_one_miss() -> None:
     rules = [_rule("vendor.name", "Acme"), _rule("vendor.city", "Austin")]
     uni = compute_unified_evidence_metrics(expected, actual, rules, [], schema)
     assert _val(uni, "extract_unified_value_recall") == 0.0
-    assert _val(uni, "extract_unified_value_precision") == 0.0
-    # Two implicit-null children (root ``.get``), not one opaque cell.
-    assert _val(uni, "extract_unified_value_recall") == _val(uni, "extract_unified_value_precision")
+    # No field ``default`` → omit is not an implicit null prediction.
+    explicit_nulls = compute_unified_evidence_metrics(
+        expected, {"vendor": {"name": None, "city": None}}, rules, [], schema
+    )
+    omitted_meta = next(m.metadata for m in uni if m.metric_name == "extract_unified_value_recall")
+    explicit_meta = next(m.metadata for m in explicit_nulls if m.metric_name == "extract_unified_value_recall")
+    assert omitted_meta["expected_cells"] == 2
+    assert omitted_meta["predicted_cells"] == 0
+    assert explicit_meta["predicted_cells"] == 2
+
+
+def test_omitted_object_uses_schema_field_defaults() -> None:
+    schema = {
+        "type": "object",
+        "$defs": {
+            "Vendor": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "default": "Acme"},
+                    "city": {"type": "string", "default": None},
+                },
+            }
+        },
+        "properties": {
+            "vendor": {"anyOf": [{"$ref": "#/$defs/Vendor"}, {"type": "null"}], "default": None},
+        },
+    }
+    expected = {"vendor": {"name": "Acme", "city": "Austin"}}
+    actual: dict[str, Any] = {}
+    rules = [_rule("vendor.name", "Acme"), _rule("vendor.city", "Austin")]
+    uni = compute_unified_evidence_metrics(expected, actual, rules, [], schema)
+    # name matches the explicit schema default; city default is null ≠ Austin.
+    assert _val(uni, "extract_unified_value_recall") == 0.5
+    assert _val(uni, "extract_unified_value_precision") == 0.5
+    meta = next(m.metadata for m in uni if m.metric_name == "extract_unified_value_recall")
+    assert meta["expected_cells"] == 2
+    assert meta["predicted_cells"] == 2
 
 
 def test_null_object_matches_omitted_and_explicit_null() -> None:
     schema = {
         "type": "object",
-        "properties": {"vendor": {"type": ["object", "null"]}},
+        "properties": {"vendor": {"type": ["object", "null"], "default": None}},
     }
     expected = {"vendor": None}
     rules = [_rule("vendor", None)]
@@ -343,6 +378,35 @@ def test_null_object_matches_omitted_and_explicit_null() -> None:
     explicit = compute_unified_evidence_metrics(expected, {"vendor": None}, rules, [], schema)
     assert _val(omitted, "extract_unified_value_f1") == 1.0
     assert _val(explicit, "extract_unified_value_f1") == 1.0
+
+
+def test_nested_object_scalar_array_is_one_opaque_cell() -> None:
+    # Schema-typed primitive arrays on nested objects are one opaque cell (same
+    # as a string field), not a Hungarian table and not a skip. Disagreeing
+    # lists are 0/0; matching lists are 1/1. Per-element scoring of ["a","b"] vs
+    # ["a","c"] would be 0.5, so these bounds also pin "one cell".
+    schema = {
+        "type": "object",
+        "properties": {
+            "vendor": {
+                "type": "object",
+                "properties": {
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": ["string", "null"]},
+                    }
+                },
+            }
+        },
+    }
+    expected = {"vendor": {"tags": ["a", "b"]}}
+    rules = [_rule("vendor.tags", ["a", "b"])]
+    miss = compute_unified_evidence_metrics(expected, {"vendor": {"tags": ["a", "c"]}}, rules, [], schema)
+    hit = compute_unified_evidence_metrics(expected, expected, rules, [], schema)
+    assert _val(miss, "extract_unified_value_recall") == 0.0
+    assert _val(miss, "extract_unified_value_precision") == 0.0
+    assert _val(hit, "extract_unified_value_recall") == 1.0
+    assert _val(hit, "extract_unified_value_precision") == 1.0
 
 
 def test_object_inside_array_row_recurses_to_child_cells() -> None:
@@ -647,6 +711,157 @@ def test_array_records_with_nested_object_and_nested_object_array() -> None:
     assert _val(uni, "extract_unified_value_recall") > _val(arr, "array_record_recall")
 
 
+def test_hungarian_pairs_rows_by_nested_object_children() -> None:
+    """Same opaque scalars, nested objects that only partially overlap.
+
+    Whole-dict pairing cost is 1 for every gold/pred pair (no issuer dict is
+    identical), so Hungarian can follow list order and score children under the
+    wrong partner: 2 scalar hits, 0 nested hits → 2/6. Child-level cost prefers
+    the crossed pairing (each row matches city, misses zip) → 4/6.
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "holdings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "class": {"type": ["string", "null"]},
+                        "issuer": {
+                            "type": "object",
+                            "properties": {
+                                "city": {"type": ["string", "null"]},
+                                "zip": {"type": ["string", "null"]},
+                            },
+                        },
+                    },
+                },
+            }
+        },
+    }
+    expected = {
+        "holdings": [
+            {"class": "equity", "issuer": {"city": "NYC", "zip": "10001"}},
+            {"class": "equity", "issuer": {"city": "SF", "zip": "94105"}},
+        ]
+    }
+    actual = {
+        "holdings": [
+            {"class": "equity", "issuer": {"city": "SF", "zip": "00000"}},
+            {"class": "equity", "issuer": {"city": "NYC", "zip": "00000"}},
+        ]
+    }
+    uni = compute_unified_evidence_metrics(expected, actual, [], [], schema)
+    assert _val(uni, "extract_unified_value_recall") == 4 / 6
+    assert _val(uni, "extract_unified_value_precision") == 4 / 6
+    arr = ArrayRecordMatchMetric().compute(expected=expected, actual=actual, data_schema=schema)
+    # array_record still treats issuer as one opaque cell: list-order pairing,
+    # class matches, issuer dicts all miss → 2/4.
+    assert _val(arr, "array_record_recall") == 2 / 4
+
+
+def test_pairing_walks_schema_keys_that_contain_dots() -> None:
+    """A key named ``a.b`` is one field, not a nested ``a`` then ``b``.
+
+    Same opaque scalar, nested objects that only overlap on that dotted key.
+    Splitting the path on ``.`` would read missing children and list-order pair
+    (2/6). Segment walks pair on ``a.b`` (4/6).
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "holdings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "class": {"type": ["string", "null"]},
+                        "issuer": {
+                            "type": "object",
+                            "properties": {
+                                "a.b": {"type": ["string", "null"]},
+                                "zip": {"type": ["string", "null"]},
+                            },
+                        },
+                    },
+                },
+            }
+        },
+    }
+    expected = {
+        "holdings": [
+            {"class": "equity", "issuer": {"a.b": "NYC", "zip": "10001"}},
+            {"class": "equity", "issuer": {"a.b": "SF", "zip": "94105"}},
+        ]
+    }
+    actual = {
+        "holdings": [
+            {"class": "equity", "issuer": {"a.b": "SF", "zip": "00000"}},
+            {"class": "equity", "issuer": {"a.b": "NYC", "zip": "00000"}},
+        ]
+    }
+    uni = compute_unified_evidence_metrics(expected, actual, [], [], schema)
+    assert _val(uni, "extract_unified_value_recall") == 4 / 6
+    assert _val(uni, "extract_unified_value_precision") == 4 / 6
+
+
+def test_nested_object_array_alts_participate_in_parent_pairing() -> None:
+    """Alts on nested object-array leaves must affect parent Hungarian cost.
+
+    Parent scalars tie. Without alts, list-order nested cost is worse than the
+    crossed pairing, so the solver swaps and gold[1] misses applez (3/4). With
+    alts in the nested cost, list order is free and both names match (4/4).
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "cls": {"type": ["string", "null"]},
+                        "loc": {
+                            "type": "object",
+                            "properties": {
+                                "aliases": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {"name": {"type": ["string", "null"]}},
+                                    },
+                                }
+                            },
+                        },
+                    },
+                },
+            }
+        },
+    }
+    expected = {
+        "rows": [
+            {"cls": "x", "loc": {"aliases": [{"name": "apple"}]}},
+            {"cls": "x", "loc": {"aliases": [{"name": "apples"}]}},
+        ]
+    }
+    actual = {
+        "rows": [
+            {"cls": "x", "loc": {"aliases": [{"name": "applez"}]}},
+            {"cls": "x", "loc": {"aliases": [{"name": "apple"}]}},
+        ]
+    }
+    rules = [
+        _rule("rows[0].cls", "x"),
+        _rule("rows[0].loc.aliases[0].name", "apple", "applez"),
+        _rule("rows[1].cls", "x"),
+        _rule("rows[1].loc.aliases[0].name", "apples", "apple"),
+    ]
+    uni = compute_unified_evidence_metrics(expected, actual, rules, [], schema)
+    assert _val(uni, "extract_unified_value_recall") == 1.0
+    assert _val(uni, "extract_unified_value_precision") == 1.0
+
+
 # ------------------------------------------------------------- grounding
 def _bbox_rules(expected: dict[str, Any], page: int, bbox: list[float]) -> list[ExtractFieldTestRule]:
     rules = [_rule("as_of", expected.get("as_of"))]
@@ -685,6 +900,37 @@ def test_iou_xywh_clamps_identical_non_dyadic_boxes_to_one() -> None:
     box = (0.1, 0.2, 0.3, 0.4)
     assert iou_xywh(box, box) == 1.0
     assert iou_xywh(box, (0.9, 0.9, 0.05, 0.05)) == 0.0
+
+
+def test_iou_xywh_identical_malformed_boxes_are_not_perfect_hits() -> None:
+    nan = float("nan")
+    inf = float("inf")
+    assert iou_xywh((nan, nan, nan, nan), (nan, nan, nan, nan)) == 0.0
+    assert iou_xywh((0.0, 0.0, inf, inf), (0.0, 0.0, inf, inf)) == 0.0
+    assert iou_xywh((0.1, 0.2, 0.0, 0.4), (0.1, 0.2, 0.0, 0.4)) == 0.0
+    assert iou_xywh((0.1, 0.2, 0.3, 0.0), (0.1, 0.2, 0.3, 0.0)) == 0.0
+
+
+def test_indexers_drop_non_finite_or_non_positive_bboxes() -> None:
+    nan = float("nan")
+    inf = float("inf")
+    rules = [
+        _rule("as_of", "x", page=1, bbox=[0.1, 0.2, nan, 0.4]),
+        _rule("holdings[0].security", "AAA", page=1, bbox=[0.1, 0.2, inf, 0.4]),
+        _rule("holdings[0].coupon", 1.0, page=1, bbox=[0.1, 0.2, 0.0, 0.4]),
+        _rule("holdings[0].note", "n", page=1, bbox=[0.1, 0.2, 0.3, -0.1]),
+    ]
+    _, ev_boxes, _, *_ = build_rule_indexes(rules)
+    pred_boxes, _ = index_citations(
+        [
+            {"field_path": "as_of", "page": 1, "bbox": [0.1, 0.2, nan, 0.4]},
+            {"field_path": "holdings[0].security", "page": 1, "bbox": [0.1, 0.2, inf, 0.4]},
+            {"field_path": "holdings[0].coupon", "page": 1, "bbox": [0.1, 0.2, 0.0, 0.4]},
+            {"field_path": "holdings[0].note", "page": 1, "bbox": [0.1, 0.2, 0.3, -0.1]},
+        ]
+    )
+    assert ev_boxes == {}
+    assert pred_boxes == {}
 
 
 def test_no_citations_yields_zero_grounded() -> None:
@@ -1068,7 +1314,10 @@ def _scalar_schema(field: str, typ: str = "string") -> dict[str, Any]:
 
 
 def test_null_equals_false_normalizer_accepts_blank_checkbox_both_ways() -> None:
-    schema = _scalar_schema("swr37_bw_hearing", "boolean")
+    schema = {
+        "type": "object",
+        "properties": {"swr37_bw_hearing": {"type": ["boolean", "null"], "default": None}},
+    }
 
     # GT False, model omitted the field entirely.
     omitted = compute_unified_evidence_metrics(
@@ -1245,22 +1494,147 @@ def test_punctuation_spacing_normalizer_is_opt_in() -> None:
     assert _val(different, "extract_unified_value_f1") == 0.0
 
 
-def test_omitted_scalar_counts_as_implicit_null_prediction_right_or_wrong() -> None:
-    """Omission is scored exactly like an explicit null: it always enters the
-    precision denominator, so dropping an uncertain field cannot outscore
-    asserting it."""
+def test_omitted_scalar_without_default_is_not_implicit_null() -> None:
+    """A missing key with no schema ``default`` is absent, not predicted null."""
     schema = {
         "type": "object",
         "properties": {"a": {"type": ["string", "null"]}, "b": {"type": ["string", "null"]}},
     }
     rules = [_rule("a", "x"), _rule("b", None)]
-
     omitted = compute_unified_evidence_metrics({"a": "x", "b": None}, {}, rules, [], schema)
     explicit = compute_unified_evidence_metrics({"a": "x", "b": None}, {"a": None, "b": None}, rules, [], schema)
+    omitted_meta = next(m.metadata for m in omitted if m.metric_name == "extract_unified_value_recall")
+    explicit_meta = next(m.metadata for m in explicit if m.metric_name == "extract_unified_value_recall")
+    assert omitted_meta["expected_cells"] == 2
+    assert omitted_meta["predicted_cells"] == 0
+    assert explicit_meta["predicted_cells"] == 2
 
+
+def test_omitted_scalar_with_null_default_matches_explicit_null() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"type": ["string", "null"], "default": None},
+            "b": {"type": ["string", "null"], "default": None},
+        },
+    }
+    rules = [_rule("a", "x"), _rule("b", None)]
+    omitted = compute_unified_evidence_metrics({"a": "x", "b": None}, {}, rules, [], schema)
+    explicit = compute_unified_evidence_metrics({"a": "x", "b": None}, {"a": None, "b": None}, rules, [], schema)
     assert _val(omitted, "extract_unified_value_precision") == 0.5
     assert _val(omitted, "extract_unified_value_precision") == _val(explicit, "extract_unified_value_precision")
     assert _val(omitted, "extract_unified_value_recall") == _val(explicit, "extract_unified_value_recall")
+
+
+def test_lookup_present_key_wins_including_explicit_null() -> None:
+    schema = {"type": ["string", "null"], "default": "x"}
+    assert lookup({"a": None}, "a", schema) == (True, None)
+    assert lookup({"a": "y"}, "a", schema) == (True, "y")
+    assert lookup({}, "a", schema) == (True, "x")
+    assert lookup({}, "a", {"type": "string"}) == (False, None)
+    assert lookup({}, "a", {"default": None}) == (True, None)
+
+
+def test_explicit_null_vs_omit_without_default_is_one_sided() -> None:
+    schema = {"type": "object", "properties": {"a": {"type": ["string", "null"]}}}
+    rules = [_rule("a", None)]
+    omit_pred = compute_unified_evidence_metrics({"a": None}, {}, rules, [], schema)
+    omit_gold = compute_unified_evidence_metrics({}, {"a": None}, rules, [], schema)
+    both = compute_unified_evidence_metrics({"a": None}, {"a": None}, rules, [], schema)
+    omit_pred_meta = next(m.metadata for m in omit_pred if m.metric_name == "extract_unified_value_recall")
+    omit_gold_meta = next(m.metadata for m in omit_gold if m.metric_name == "extract_unified_value_recall")
+    assert omit_pred_meta["expected_cells"] == 1
+    assert omit_pred_meta["predicted_cells"] == 0
+    assert omit_gold_meta["expected_cells"] == 0
+    assert omit_gold_meta["predicted_cells"] == 1
+    assert _val(both, "extract_unified_value_f1") == 1.0
+
+
+def test_omitted_scalar_with_non_null_default_is_a_real_value() -> None:
+    schema = {"type": "object", "properties": {"name": {"type": "string", "default": "Acme"}}}
+    match = compute_unified_evidence_metrics({"name": "Acme"}, {}, [_rule("name", "Acme")], [], schema)
+    miss = compute_unified_evidence_metrics({"name": "Beta"}, {}, [_rule("name", "Beta")], [], schema)
+    assert _val(match, "extract_unified_value_f1") == 1.0
+    assert _val(miss, "extract_unified_value_recall") == 0.0
+    assert _val(miss, "extract_unified_value_precision") == 0.0
+    miss_meta = next(m.metadata for m in miss if m.metric_name == "extract_unified_value_recall")
+    assert miss_meta["expected_cells"] == 1
+    assert miss_meta["predicted_cells"] == 1
+
+
+def test_both_sides_omit_defaulted_root_field() -> None:
+    """Schema names, not instance keys, are the cell universe (plus lookup)."""
+    schema = {"type": "object", "properties": {"name": {"type": "string", "default": "Acme"}}}
+    uni = compute_unified_evidence_metrics({}, {}, [_rule("name", "Acme")], [], schema)
+    assert _val(uni, "extract_unified_value_f1") == 1.0
+    meta = next(m.metadata for m in uni if m.metric_name == "extract_unified_value_recall")
+    assert meta["expected_cells"] == 1
+    assert meta["predicted_cells"] == 1
+
+
+def test_both_sides_omit_root_field_without_default_is_not_a_cell() -> None:
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    uni = compute_unified_evidence_metrics({}, {}, [_rule("name", "Acme")], [], schema)
+    assert uni == []
+
+
+def test_nested_object_child_omit_uses_field_default() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "vendor": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "default": "Acme"},
+                    "city": {"type": ["string", "null"]},
+                },
+            }
+        },
+    }
+    expected = {"vendor": {"name": "Acme", "city": "Austin"}}
+    actual = {"vendor": {}}
+    rules = [_rule("vendor.name", "Acme"), _rule("vendor.city", "Austin")]
+    uni = compute_unified_evidence_metrics(expected, actual, rules, [], schema)
+    meta = next(m.metadata for m in uni if m.metric_name == "extract_unified_value_recall")
+    # name defaulted to Acme (match); city absent (recall-only, not a null prediction).
+    assert meta["expected_cells"] == 2
+    assert meta["predicted_cells"] == 1
+    assert _val(uni, "extract_unified_value_recall") == 0.5
+    assert _val(uni, "extract_unified_value_precision") == 1.0
+
+
+def test_in_row_object_child_omit_uses_schema_default() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": ["string", "null"]},
+                        "addr": {
+                            "type": "object",
+                            "properties": {
+                                "city": {"type": "string", "default": "Austin"},
+                                "zip": {"type": ["string", "null"]},
+                            },
+                        },
+                    },
+                },
+            }
+        },
+    }
+    expected = {"rows": [{"id": "1", "addr": {"city": "Austin", "zip": "1"}}]}
+    actual = {"rows": [{"id": "1", "addr": {}}]}
+    rules = [_rule("rows[0].id", "1"), _rule("rows[0].addr.city", "Austin"), _rule("rows[0].addr.zip", "1")]
+    uni = compute_unified_evidence_metrics(expected, actual, rules, [], schema)
+    meta = next(m.metadata for m in uni if m.metric_name == "extract_unified_value_recall")
+    # id match + city default match; zip absent (recall-only).
+    assert meta["expected_cells"] == 3
+    assert meta["predicted_cells"] == 2
+    assert _val(uni, "extract_unified_value_recall") == 2 / 3
+    assert _val(uni, "extract_unified_value_precision") == 1.0
 
 
 def test_supported_normalizers_match_schema_vocabulary() -> None:
@@ -1321,7 +1695,7 @@ def test_giant_grounded_array_skips_grounding_value_exact_and_peels(monkeypatch:
 
 def test_giant_threshold_does_not_touch_nested_or_below_threshold(monkeypatch: Any) -> None:
     """The skip must not fire for arrays with nested object arrays (peel would shift
-    nested TP -- the #1537 hazard), nor below the threshold."""
+    nested TP), nor below the threshold."""
     box = [0.0, 0.0, 10.0, 10.0]
     expected = {"as_of": None, "holdings": [{"security": "A", "coupon": 1.0, "note": "n"}]}
     rules = _bbox_rules(expected, page=1, bbox=box)

--- a/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py
@@ -761,6 +761,52 @@ def test_hungarian_pairs_rows_by_nested_object_children() -> None:
     assert _val(arr, "array_record_recall") == 2 / 4
 
 
+def test_hungarian_pairing_fills_omitted_nested_defaults() -> None:
+    """Pairing must read omitted nested keys as schema defaults, not ``None``.
+
+    Gold row 0 omits ``city`` (default Austin); gold row 1 sets ``city`` to
+    explicit null. Pred list-order swaps those two issuer objects. A ``.get``
+    walk sees ``None`` on every city cell, so Hungarian keeps list order and
+    scores Austin vs null on both pairs (2/4). Lookup pairing crosses the
+    rows: omit matches omit, null matches null (4/4).
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "holdings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "class": {"type": ["string", "null"]},
+                        "issuer": {
+                            "type": "object",
+                            "properties": {
+                                "city": {"type": ["string", "null"], "default": "Austin"},
+                            },
+                        },
+                    },
+                },
+            }
+        },
+    }
+    expected = {
+        "holdings": [
+            {"class": "equity", "issuer": {}},
+            {"class": "equity", "issuer": {"city": None}},
+        ]
+    }
+    actual = {
+        "holdings": [
+            {"class": "equity", "issuer": {"city": None}},
+            {"class": "equity", "issuer": {}},
+        ]
+    }
+    uni = compute_unified_evidence_metrics(expected, actual, [], [], schema)
+    assert _val(uni, "extract_unified_value_recall") == 1.0
+    assert _val(uni, "extract_unified_value_precision") == 1.0
+
+
 def test_pairing_walks_schema_keys_that_contain_dots() -> None:
     """A key named ``a.b`` is one field, not a nested ``a`` then ``b``.
 


### PR DESCRIPTION
## Summary
- Treat nested primitive arrays (`string[]`, `number[]`, and null combinators) as one opaque cell instead of silently skipping them.
- Pair nested objects and nested object-arrays with Hungarian cost over child fields, not 0/1 dict equality.
- Fill omitted keys from JSON Schema `default` when present; without `default`, an omitted key is a one-sided miss. Pairing and F1 both use `lookup` — including opaque array-row cells — so omit, explicit `null`, and `0` stay distinct (`0 != null`; missing equals `0` only when `"default": 0`).
- One-sided misses skip schema children gold never asserted (absent and no `default`).
- Treat NaN/Inf/zero-size bbox IoU as a miss. Envelope grounding, per-layer F1, and Extract Element Pass Rate are unchanged. `array_record` still reads omitted keys with `.get`.

## Test plan
- [x] `uv run --extra dev python -m pytest tests/extract_bench/evaluation/metrics/extract/test_unified_evidence_metric.py tests/extract_bench/evaluation/metrics/extract/test_array_record_match_metric.py`
- [x] Regression tests for reversed `0` vs `null` rows, omit vs explicit `null`, defaulted array columns, array-row lookup matching objects, and unasserted children on a one-sided miss
- [ ] Re-score a cached extract run after merge if leaderboard numbers should reflect the new pairing / nested-array cells