### PR TITLE
fix: Align the extract scorer with the internal fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to `extract-bench` are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+Pulls the extract scorer into alignment with the internal LlamaCloud benchmark
+harness ahead of the first PyPI release.
+
+### Scoring (changes evaluation numbers)
+- Unified extract F1: a key omitted from a prediction resolves to the JSON
+  Schema `default` when the property declares one; without a default it is a
+  one-sided miss rather than an implicit `null` prediction. Omitted, explicit
+  `null` and `0` are three distinct cells (`0 != null`; an omitted key equals
+  `0` only under `"default": 0`). Defaulted fields omitted on both sides count
+  as matches.
+- Unified extract F1: nested primitive arrays (`tags: ["a", "b"]`) score as one
+  opaque cell instead of being dropped from the cell count.
+- Unified extract F1: Hungarian row pairing for object arrays counts nested
+  object children and nested object arrays in the assignment cost, and reads
+  nested leaves through the same schema-default lookup as scoring, so rows are
+  aligned on the full leaf set F1 actually grades.
+- Unified grounding: envelope match mode (`bbox_match_mode="envelope"`, the
+  default). A `coarse` evidence entry is graded as an AND over the precise
+  boxes it encloses on its page; a citation must cover the whole envelope, not
+  one of its lines. Identical to the previous behaviour on ground truth with no
+  coarse entries.
+- Unified grounding: non-finite or non-positive predicted boxes score as
+  misses instead of propagating `NaN` through IoU.
+- JSON subset match: ground truth is no longer mutated during scoring (a second
+  pass over the same objects saw a stripped nested `check_number`). Unweighted
+  mode scores an empty expected list against a non-empty actual list as 0.
+- Removed the extract-side metrics that cannot fire on the published ground
+  truth (every sidecar is v0.2 `_field_rules`): the legacy element-pass-rate /
+  loc / attr / `extract_avg_iou*` family, bare `precision` / `recall` / `f1` /
+  `iou` / `bbox_recall`, `record_*`, `null_hallucination_rate`,
+  `extract_field_value_pass_rate`, `schema_field_accuracy_*`, extract-side
+  `rule_pass_rate` / `rule_array_*`, and `association_f1`. `extract_unified_*`,
+  `extract_evidence_*`, `accuracy`, `array_record_*` and
+  `confidence_scoped_*` are unchanged.
+
+### Added
+- `FieldEvidence.layer` names the bbox geometry when the same location is
+  annotated more than once (`word`, `structural`, `checkbox`, ...), so ground
+  truth written for the internal harness loads unchanged. Unknown names are
+  rejected at load time. The headline grounded F1 ORs every box regardless of
+  layer; per-layer metrics are not emitted.
+- `deepseek_v4_1_flash_extract_oneshot_structured_output_file` pipeline:
+  DeepSeek-V4.1-Flash over page images with thinking disabled
+  (`DEEPSEEK_API_KEY`).
+- `test_rules` entries typed `layout_line` / `layout_word` load as layout rules
+  with the matching granularity.

--- a/src/extract_bench/evaluation/metrics/extract/json_subset_match.py
+++ b/src/extract_bench/evaluation/metrics/extract/json_subset_match.py
@@ -35,9 +35,13 @@ def normalize_date_string(date_str: Any) -> Any:
     if re.search(r"\d{10,}", date_str):
         return date_str
 
-    # "March 28,1956" and "March 27 ,1956" are the same date as "March 27, 1956".
-    # Normalize on a probe copy only. Comma-only: this runs on every string leaf,
-    # and a wider rewrite would widen what counts as a date everywhere.
+    # Spacing around the comma carries no meaning: "March 28,1956" and
+    # "March 27 ,1956" name the same date as "March 27, 1956". Normalize the
+    # comma to ", " on a probe copy so these variants clear the pattern gate
+    # and parse; the original is still what we return unchanged when it is not
+    # a date. Comma-gated and comma-only on purpose: this function runs on
+    # every string leaf of every dataset, and a wider rewrite (e.g. collapsing
+    # doubled spaces) would silently widen what counts as a date everywhere.
     probe = _COMMA_WS_RE.sub(", ", date_str) if "," in date_str else date_str
 
     date_patterns = [
@@ -104,7 +108,10 @@ def _normalize_payment_details_entry(entry: Any) -> Any:
     if "checks" in out and "check" not in out:
         checks = out["checks"]
         if isinstance(checks, list) and checks and isinstance(checks[0], dict):
-            out["check"] = checks[0]
+            # Copy: ``out`` is only a shallow copy of ``entry``, so ``checks[0]``
+            # is still the caller's dict and later rewrites of ``out["check"]``
+            # would reach back into the input.
+            out["check"] = dict(checks[0])
             out.pop("checks", None)
 
     # Flat check_* fields -> nested check: {...}.
@@ -119,7 +126,13 @@ def _normalize_payment_details_entry(entry: Any) -> Any:
     # Top-level value (if already present) wins over the nested fallback.
     nested_check = out.get("check") if isinstance(out.get("check"), dict) else None
     if nested_check is not None and "check_number" in nested_check:
-        nested_value = nested_check.pop("check_number")
+        nested_value = nested_check["check_number"]
+        # Rebuild the nested check without check_number instead of pop()-ing it:
+        # ``out`` is only a shallow copy of ``entry``, so ``out["check"]`` may be
+        # the caller's dict. Popping mutates the caller's input, so a second score
+        # of the same objects sees ground truth that no longer carries the nested
+        # check_number. Assigning a fresh dict leaves ``entry`` untouched.
+        out["check"] = {k: v for k, v in nested_check.items() if k != "check_number"}
         if "check_number" not in out:
             out["check_number"] = nested_value
 
@@ -163,9 +176,9 @@ def normalize_field_aliases(obj: Any) -> Any:
     return obj
 
 
-# Field names that identify a record, so list elements pair by identity
-# instead of index. Only unambiguous identifiers: generic ``name`` or
-# ``date`` would false-pair.
+# Field names that identify a record so list elements can be paired by
+# identity instead of by index. Conservative on purpose: only keys that are
+# unambiguously identifiers — generic ``name`` or ``date`` would false-pair.
 _IDENTITY_FIELD_NAMES: tuple[str, ...] = (
     "claim_number",
     "claim_id",
@@ -465,7 +478,12 @@ def _compute_score_with_weight(
         if len(expected) == 0 and len(actual) == 0:
             return (1.0, 1)
         if len(expected) == 0:
-            return (1.0, 1)
+            # `actual` is non-empty here. Weighted mode (the default) keeps
+            # subset semantics: an empty expected list makes no claim about
+            # what the extractor returned. Unweighted mode mirrors upstream
+            # scoring, which divides by max(len(expected), len(actual)) and so
+            # scores the over-extraction 0.
+            return (1.0, 1) if weighted else (0.0, 1)
         if len(actual) == 0:
             # All expected items missing - weight by expected's full leaf
             # count so a dropped 15-claim array is penalized by 15 × per-claim
@@ -521,13 +539,10 @@ def _compute_score_with_weight(
         exp_identities = [_record_identity(item) for item in expected]
         if exp_identities and all(i is not None for i in exp_identities):
             actual_by_identity: dict[str, Any] = {}
-            unclaimed_actual: list[Any] = []
             for item in actual:
                 aid = _record_identity(item)
                 if aid is not None and aid not in actual_by_identity:
                     actual_by_identity[aid] = item
-                else:
-                    unclaimed_actual.append(item)
             list_results: list[tuple[float, int]] = []
             for i, exp_item in enumerate(expected):
                 eid = exp_identities[i]

--- a/src/extract_bench/test_cases/schema.py
+++ b/src/extract_bench/test_cases/schema.py
@@ -198,6 +198,20 @@ EXTRACT_FIELD_NORMALIZERS: frozenset[str] = frozenset(
 )
 
 
+# Named grounding geometries on a FieldEvidence bbox. Headline
+# extract_unified_grounded_f1 ORs every box regardless of layer. Unknown names
+# are rejected at load time so a typo cannot silently create a new layer.
+EVIDENCE_LAYERS: frozenset[str] = frozenset(
+    {
+        "word",  # tight ink of the value
+        "structural",  # the enclosed form/table cell holding the value
+        "checkbox",  # boolean true: the mark glyph / square only
+        "checkbox_label",  # boolean true: the printed option label only
+        "checkbox_with_label",  # boolean true: mark + label together
+    }
+)
+
+
 class FieldEvidence(BaseModel):
     """One accepted location for a field's value (v0.2 evidence list entry).
 
@@ -222,8 +236,35 @@ class FieldEvidence(BaseModel):
     )
     coarse: bool = Field(
         default=False,
-        description="True when this is a parent-level cite or page-only evidence.",
+        description=(
+            "True for a coarser location: the envelope of the precise entries it "
+            "encloses on its page (a value printed on several lines carries one "
+            "entry per line plus their union, flagged coarse), a parent-level "
+            "cite, or page-only evidence. The default envelope grounding mode "
+            "grades a citation against the whole envelope, never one of its lines."
+        ),
     )
+    layer: str | None = Field(
+        default=None,
+        description=(
+            "Optional named bbox geometry when the same location is annotated "
+            "more than once. None = unlabeled gold. Unknown names are rejected "
+            "at load time (see EVIDENCE_LAYERS)."
+        ),
+    )
+
+    @field_validator("layer")
+    @classmethod
+    def _validate_layer(cls, value: str | None) -> str | None:
+        # Keep the field typed as str, not a Literal of current layer names. A
+        # Literal would export as a JSON Schema enum and freeze the layer list
+        # for any consumer of the dumped schema. Load-time membership in
+        # EVIDENCE_LAYERS still rejects typos; adding a layer is a set update.
+        if value is None:
+            return None
+        if value not in EVIDENCE_LAYERS:
+            raise ValueError(f"Unknown evidence layer {value!r}; supported: {sorted(EVIDENCE_LAYERS)}")
+        return value
 
 
 class ExtractFieldTestRule(BaseModel):
@@ -454,8 +495,19 @@ def _coerce_mixed_rule_list(
 
         if isinstance(rule, dict):
             rule_type = rule.get("type")
-            if rule_type == "layout":
-                typed_rules.append(LayoutTestRule.model_validate(rule))
+            if rule_type in {"layout", "layout_line", "layout_word"}:
+                if rule_type == "layout":
+                    typed_rules.append(LayoutTestRule.model_validate(rule))
+                    continue
+
+                granularity = "line" if rule_type == "layout_line" else "word"
+                normalized_rule = {
+                    **rule,
+                    "type": "layout",
+                    "granularity": rule.get("granularity") or granularity,
+                }
+                normalized_rule.setdefault("canonical_class", "Text")
+                typed_rules.append(LayoutTestRule.model_validate(normalized_rule))
             elif rule_type == "extract_field":
                 typed_rules.append(ExtractFieldTestRule.model_validate(rule))
             else:

--- a/tests/extract_bench/evaluation/metrics/extract/test_json_subset_match.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_json_subset_match.py
@@ -1,12 +1,546 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Mapping
 from typing import Any
 
 from extract_bench.evaluation.metrics.extract.json_subset_match import (
     _is_nullable_numeric_field,
     json_subset_match_score,
+    normalize_date_string,
+    normalize_field_aliases,
 )
+
+
+def test_normalize_date_string_handles_weekday_prefix_with_periods() -> None:
+    assert normalize_date_string("Mon. Jan. 02 2023") == "2023-01-02"
+    assert normalize_date_string("Fri. Dec. 29 2023") == "2023-12-29"
+
+
+def test_normalize_date_string_tolerates_comma_spacing() -> None:
+    assert normalize_date_string("March 27 ,1956") == "1956-03-27"
+    assert normalize_date_string("March 28,1956") == "1956-03-28"
+
+
+def test_json_subset_match_scores_weekday_date_equivalence() -> None:
+    score = json_subset_match_score(
+        {"attendance_records": [{"date": "2023-01-02"}]},
+        {"attendance_records": [{"date": "Mon. Jan. 02 2023"}]},
+    )
+
+    assert score == 1.0
+
+
+# Regression tests: missing arrays/dicts must be weighted by the full leaf
+# count of `expected`, not weight=1. Otherwise a pipeline that drops a whole
+# claims array can score the same as one that extracts it.
+
+
+def test_missing_top_level_array_weighted_by_full_leaf_count() -> None:
+    """A 15-claim array dropped entirely must outweigh a 1-leaf scalar field."""
+    expected = {
+        "scalar_field": "x",
+        "claims": [{"a": 1, "b": 2, "c": 3} for _ in range(15)],
+    }
+    actual = {"scalar_field": "x"}
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # 1 leaf right out of 46 total => ~0.022. Pre-fix this was ~0.5 because
+    # the missing claims array was treated as a single weight=1 leaf.
+    assert score < 0.05, f"expected score <0.05, got {score}"
+
+
+def test_missing_array_same_as_empty_array() -> None:
+    """An absent key and `[]` should score identically when expected is non-empty."""
+    expected = {"claims": [{"a": 1, "b": 2}]}
+    score_missing = json_subset_match_score(expected, {}, weighted=True)
+    score_empty = json_subset_match_score(expected, {"claims": []}, weighted=True)
+    assert score_missing == score_empty == 0.0
+
+
+def test_missing_nested_dict_weighted_by_subtree() -> None:
+    """A dropped nested dict must be weighted by its leaf count."""
+    expected = {
+        "id": "x",
+        "patient": {
+            "first_name": "A",
+            "last_name": "B",
+            "address": {"city": "X", "zip": "1"},
+        },
+    }
+    actual = {"id": "x"}
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # 1/5 = 0.20
+    assert 0.18 < score < 0.22, f"expected ~0.20, got {score}"
+
+
+def test_partial_array_drop_weights_each_missing_item_recursively() -> None:
+    """Dropping the tail of an array must penalize by per-item leaves."""
+    expected = {
+        "claims": [
+            {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5},
+            {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5},
+            {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5},
+        ]
+    }
+    actual = {"claims": [{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}]}
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # 5/15 = ~0.33. Pre-fix this would be ~0.78 because each missing tail
+    # item only contributed weight=1.
+    assert 0.30 < score < 0.40, f"expected ~0.33, got {score}"
+
+
+def test_eob_pattern_dropped_claims_scores_low() -> None:
+    """Reproducer for the agentic-vs-continuous gh_internal puzzle.
+
+    When a pipeline returns payment_details correctly but doesn't emit
+    claims at all on a doc that has 15 claims with ~10 fields each, the
+    score should reflect that ~150 claim-leaves are missing, not weight=1.
+    """
+    expected = {
+        "payment_details": [
+            {
+                "check": {"check_number": "X", "check_amount": 100, "check_date": "2026-01-01"},
+                "payer": {"payer_name": "P", "payer_phone": "555"},
+                "payee": {"payee_name": "Q"},
+            }
+        ],
+        "claims": [
+            {
+                "claim_number": f"C{i}",
+                "patient_name": f"P{i}",
+                "total_paid": i * 10.0,
+                "total_submitted": i * 12.0,
+                "claim_from_date": "2026-01-01",
+                "claim_to_date": "2026-01-31",
+                "patient_account_number": f"A{i}",
+                "plan_type": "PPO",
+                "claim_status": "PAID",
+                "patient_responsibility": 0.0,
+            }
+            for i in range(15)
+        ],
+    }
+    actual = {"payment_details": expected["payment_details"]}
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # PD has 7 leaves, claims has 15 × 10 = 150 leaves. 7/157 = ~0.045.
+    # Pre-fix this scored ~0.875 (PD perfect / claims weight=1).
+    assert score < 0.10, f"dropped 15-claim array should score <0.10, got {score}"
+
+
+# Identity-keyed list pairing: when every expected record carries an
+# identity field (claim_number, payment_id, etc.) the scorer must pair
+# records by identity, not by index. Catches the failure mode where the
+# extractor returns the right records but in a slightly shifted order
+# (e.g. missed one in the middle, off-by-one for everything after that)
+# and strict index pairing punishes every subsequent pair.
+
+
+def test_identity_pairing_recovers_index_shifted_claims() -> None:
+    """Same records, shifted by one mid-list — should score nearly 1.0, not
+    ~0 the way strict index pairing penalizes the off-by-one cascade."""
+    expected = {
+        "claims": [
+            {"claim_number": "A1", "amount": 100.0},
+            {"claim_number": "A2", "amount": 200.0},
+            {"claim_number": "A3", "amount": 300.0},
+            {"claim_number": "A4", "amount": 400.0},
+        ]
+    }
+    actual = {
+        "claims": [
+            {"claim_number": "A1", "amount": 100.0},
+            # A2 dropped — extractor missed it
+            {"claim_number": "A3", "amount": 300.0},
+            {"claim_number": "A4", "amount": 400.0},
+        ]
+    }
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # 3/4 records perfectly matched by identity → ~0.75. Pre-fix this would
+    # have scored each shifted pair as a per-field mismatch, dragging the
+    # score way down because every claim_number after A1 was scored against
+    # the wrong GT record.
+    assert score >= 0.7, f"identity-paired score should be >=0.7, got {score}"
+
+
+def test_identity_pairing_penalizes_wrong_identity() -> None:
+    """If the extractor returns a record with a completely different
+    claim_number, identity pairing must NOT give it credit for any field
+    overlap with the GT record at the same index."""
+    expected = {"claims": [{"claim_number": "REAL", "amount": 100.0}]}
+    actual = {"claims": [{"claim_number": "WRONG", "amount": 100.0}]}
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # Pre-fix this scored ~0.5 because amount happened to overlap. With
+    # identity pairing the WRONG record can't pair with REAL, so the GT
+    # record counts as fully missed.
+    assert score < 0.1, f"wrong-identity record should score <0.1, got {score}"
+
+
+def test_identity_pairing_falls_back_to_assignment_when_no_identity() -> None:
+    """Lists whose elements don't carry an identity field pair by optimal
+    assignment — workloads that score arrays of strings or anonymous dicts
+    still get full credit for exact matches."""
+    expected = {"chunks": ["a", "b", "c"]}
+    actual = {"chunks": ["a", "b", "c"]}
+    assert json_subset_match_score(expected, actual, weighted=True) == 1.0
+
+    expected2 = {"rows": [{"col_a": 1, "col_b": 2}, {"col_a": 3, "col_b": 4}]}
+    actual2 = {"rows": [{"col_a": 1, "col_b": 2}, {"col_a": 3, "col_b": 4}]}
+    assert json_subset_match_score(expected2, actual2, weighted=True) == 1.0
+
+
+# Order-invariant pairing: lists without identity fields must be paired by
+# optimal assignment (Hungarian), not by index, mirroring
+# ArrayRecordMatchMetric. Shuffled-but-correct extractions should not be
+# penalized for row order.
+
+
+def test_anonymous_record_list_is_order_invariant() -> None:
+    expected = {
+        "rows": [
+            {"col_a": 1, "col_b": "x"},
+            {"col_a": 2, "col_b": "y"},
+            {"col_a": 3, "col_b": "z"},
+        ]
+    }
+    actual = {"rows": list(reversed(expected["rows"]))}
+
+    assert json_subset_match_score(expected, actual, weighted=True) == 1.0
+
+
+def test_scalar_list_is_order_invariant() -> None:
+    assert json_subset_match_score({"chunks": ["a", "b", "c"]}, {"chunks": ["c", "a", "b"]}) == 1.0
+
+
+def test_order_invariant_pairing_recovers_dropped_middle_row() -> None:
+    """A dropped middle row must cost only that row, not cascade an
+    off-by-one penalty onto every subsequent index-paired row."""
+    expected = {"rows": [{"a": i, "b": f"r{i}"} for i in range(4)]}
+    actual = {"rows": [expected["rows"][0], expected["rows"][2], expected["rows"][3]]}
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # 3 of 4 rows match perfectly, each row has 2 leaves: 6/8 = 0.75.
+    assert score == 0.75, f"expected 0.75, got {score}"
+
+
+def test_tied_assignment_prefers_index_order() -> None:
+    """When every pairing is a near-miss (uniform approximate cost matrix),
+    index order must win the tie deterministically. Pins the eps*|i-j|
+    tie-break: without it, which optimal assignment wins is an undocumented
+    scipy implementation detail, and a scipy upgrade could silently swap
+    aligned near-miss rows for crossed ones, dropping the Levenshtein
+    partial credit with no code change."""
+    expected = {"rows": [{"text": "alpha bravo"}, {"text": "charlie delta"}]}
+    # Aligned rows with one-character typos: no leaf matches exactly, so the
+    # approximate cost is 1 for every pairing — a fully tied matrix.
+    actual = {"rows": [{"text": "alpha brivo"}, {"text": "charlie delte"}]}
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    # Index-aligned pairing keeps ~0.92 Levenshtein partial credit; the
+    # crossed pairing would score near zero.
+    assert score > 0.8, f"aligned near-miss rows should keep partial credit, got {score}"
+
+
+def test_order_invariant_pairing_does_not_reward_wrong_values() -> None:
+    """Optimal assignment must not inflate scores when values are wrong —
+    a fully mismatched list still scores low."""
+    expected = {"rows": [{"a": 1}, {"a": 2}]}
+    actual = {"rows": [{"a": 7}, {"a": 8}]}
+
+    score = json_subset_match_score(expected, actual, weighted=True)
+    assert score < 0.5, f"expected <0.5, got {score}"
+
+
+def test_identity_pairing_only_engages_when_all_expected_have_identity() -> None:
+    """If some expected records carry an identity and some don't, fall
+    back to index pairing so partial-identity datasets aren't silently
+    rescored. Conservative default."""
+    expected = {
+        "claims": [
+            {"claim_number": "A", "amount": 1.0},
+            {"amount": 2.0},  # no identity
+        ]
+    }
+    # Identical actual: should score 1.0 via either pairing.
+    actual = {
+        "claims": [
+            {"claim_number": "A", "amount": 1.0},
+            {"amount": 2.0},
+        ]
+    }
+    assert json_subset_match_score(expected, actual, weighted=True) == 1.0
+
+
+def test_declared_identity_keys_recover_reordered_rows() -> None:
+    expected = {
+        "line_items": [
+            {"item_no": "0001", "description": "ALPHA", "amount": 100},
+            {"item_no": "0002", "description": "BRAVO", "amount": 200},
+            {"item_no": "0003", "description": "CHARLIE", "amount": 300},
+        ]
+    }
+    actual = {"line_items": list(reversed(expected["line_items"]))}
+    keys = {("line_items",): ["item_no"]}
+    assert json_subset_match_score(expected, actual, identity_keys_by_path=keys) == 1.0
+    # The assignment-pairing fallback also recovers pure reorders.
+    assert json_subset_match_score(expected, actual) == 1.0
+
+    # Where declared identity is stricter than assignment pairing: a row
+    # carrying the wrong identity gets no credit for overlapping fields,
+    # while assignment pairing still grants partial credit.
+    wrong_identity = {"line_items": [{"item_no": "9999", "description": "ALPHA", "amount": 100}]}
+    expected_one = {"line_items": [expected["line_items"][0]]}
+    assert json_subset_match_score(expected_one, wrong_identity, identity_keys_by_path=keys) == 0.0
+    assert json_subset_match_score(expected_one, wrong_identity) > 0.5
+
+
+def test_declared_identity_keys_scope_dropped_row_penalty() -> None:
+    expected = {
+        "line_items": [
+            {"item_no": "0001", "description": "ALPHA", "amount": 100},
+            {"item_no": "0002", "description": "BRAVO", "amount": 200},
+            {"item_no": "0003", "description": "CHARLIE", "amount": 300},
+        ]
+    }
+    actual = {"line_items": expected["line_items"][1:]}
+    keys = {("line_items",): ["item_no"]}
+    score = json_subset_match_score(expected, actual, identity_keys_by_path=keys)
+    # Two of three rows fully recovered; only the dropped row's leaves are lost.
+    assert abs(score - 2 / 3) < 1e-9
+
+
+def test_declared_identity_composite_keys_with_null_cells() -> None:
+    expected = {
+        "holdings": [
+            {"cusip": "AAA", "put_call": None, "value": 10},
+            {"cusip": "AAA", "put_call": "PUT", "value": 20},
+        ]
+    }
+    # Provider omits null keys and reorders; composite identity still pairs.
+    actual = {
+        "holdings": [
+            {"cusip": "AAA", "put_call": "PUT", "value": 20},
+            {"cusip": "AAA", "value": 10},
+        ]
+    }
+    keys = {("holdings",): ["cusip", "put_call"]}
+    assert json_subset_match_score(expected, actual, identity_keys_by_path=keys) == 1.0
+
+
+def test_declared_identity_duplicate_rows_pair_in_order() -> None:
+    expected = {"rows": [{"sku": "X", "qty": 1}, {"sku": "X", "qty": 2}]}
+    actual = {"rows": [{"sku": "X", "qty": 1}, {"sku": "X", "qty": 2}]}
+    keys = {("rows",): ["sku"]}
+    assert json_subset_match_score(expected, actual, identity_keys_by_path=keys) == 1.0
+
+
+def test_declared_identity_keys_apply_to_nested_paths() -> None:
+    expected = {"report": {"rows": [{"id": "A", "v": 1}, {"id": "B", "v": 2}]}}
+    actual = {"report": {"rows": [{"id": "B", "v": 2}, {"id": "A", "v": 1}]}}
+    keys = {("report", "rows"): ["id"]}
+    assert json_subset_match_score(expected, actual, identity_keys_by_path=keys) == 1.0
+
+
+def test_declared_identity_falls_back_for_non_dict_rows() -> None:
+    # Scalars under a declared path cannot carry identity; order-invariant
+    # assignment pairing applies, so reorders still score 1.0 and wrong
+    # values are still penalized.
+    expected = {"codes": ["A", "B", "C"]}
+    keys = {("codes",): ["item_no"]}
+    assert json_subset_match_score(expected, {"codes": ["A", "B", "C"]}, identity_keys_by_path=keys) == 1.0
+    assert json_subset_match_score(expected, {"codes": ["C", "B", "A"]}, identity_keys_by_path=keys) == 1.0
+    assert json_subset_match_score(expected, {"codes": ["X", "Y", "Z"]}, identity_keys_by_path=keys) < 1.0
+
+
+def test_declared_identity_tolerates_identity_surface_drift() -> None:
+    """Surface-form drift in an identity cell (trailing punctuation, numeric
+    formatting) must still pair the row — aligned with the v0.2 evidence
+    alignment's stable_value_key normalization — not hard-zero it. The
+    drifted cell itself still pays its per-field score after pairing."""
+    keys = {("line_items",): ["item_no"]}
+
+    expected = {"line_items": [{"item_no": "0001", "description": "ALPHA", "amount": 100}]}
+    actual = {"line_items": [{"item_no": "0001.", "description": "ALPHA", "amount": 100}]}
+    score = json_subset_match_score(expected, actual, identity_keys_by_path=keys)
+    # Row pairs; only item_no pays Levenshtein drift: (0.8 + 1 + 1) / 3.
+    assert score > 0.9, f"trailing-punctuation drift should not unpair the row, got {score}"
+
+    expected = {"line_items": [{"item_no": 100, "description": "ALPHA", "amount": 5}]}
+    actual = {"line_items": [{"item_no": "100.00", "description": "ALPHA", "amount": 5}]}
+    score = json_subset_match_score(expected, actual, identity_keys_by_path=keys)
+    # Row pairs; the int-vs-str item_no cell scores 0: (0 + 1 + 1) / 3.
+    assert score > 0.6, f"numeric-format drift should not unpair the row, got {score}"
+
+    # Genuinely different identities must still hard-zero (declared-identity
+    # strictness is about wrong identity, not drifted identity).
+    expected = {"line_items": [{"item_no": "0001", "description": "ALPHA", "amount": 100}]}
+    actual = {"line_items": [{"item_no": "0002", "description": "ALPHA", "amount": 100}]}
+    assert json_subset_match_score(expected, actual, identity_keys_by_path=keys) == 0.0
+
+
+def test_assignment_pairing_falls_back_to_index_beyond_pair_cap(monkeypatch: Any) -> None:
+    """Beyond the bounded pair budget (mirroring the v0.2 adapter's pass-2
+    cap) the n×m assignment is skipped and index pairing applies, so
+    pathological very-long arrays don't stall the evaluator."""
+    import extract_bench.evaluation.metrics.extract.json_subset_match as jsm
+
+    expected = {"rows": [{"a": i} for i in range(3)]}
+    actual = {"rows": [{"a": i} for i in reversed(range(3))]}
+
+    monkeypatch.setattr(jsm, "_ASSIGNMENT_MAX_PAIRS", 4)
+    capped = json_subset_match_score(expected, actual, weighted=True)
+    assert capped < 1.0, f"beyond the cap, index pairing should penalize reorder, got {capped}"
+
+    monkeypatch.setattr(jsm, "_ASSIGNMENT_MAX_PAIRS", 250_000)
+    assert json_subset_match_score(expected, actual, weighted=True) == 1.0
+
+
+def test_normalize_date_string_probe_is_comma_scoped() -> None:
+    """The comma-respacing probe must not widen what counts as a date: strings
+    without a comma are left exactly as before (doubled spaces included)."""
+    assert normalize_date_string("March  27 1956") == "March  27 1956"
+    assert normalize_date_string("March 27 1956") == "1956-03-27"
+
+
+# Input immutability. The evaluator scores the same `expected_output` object
+# several times (overall accuracy, per-field accuracy, per-schema-group
+# accuracy, the evidence metrics), and its ground-truth normalization only
+# shallow-copies, so payment_details entries are shared across those calls. Any
+# in-place rewrite inside the alias normalization silently changes what every
+# later call is scored against.
+
+_MUTATION_REPRO_EXPECTED: dict[str, Any] = {
+    "payment_details": [{"check": {"check_number": "12345", "check_amount": 100.0}}]
+}
+# check_number in the wrong place and wrong-valued: must score 0 every time.
+_MUTATION_REPRO_ACTUAL: dict[str, Any] = {
+    "payment_details": [{"check_number": "99999", "check": {"check_amount": 100.0}}]
+}
+
+
+def test_scoring_does_not_mutate_expected() -> None:
+    """`expected` must come back byte-identical — the nested check_number lift
+    used to pop the key out of the caller's ground truth."""
+    expected = copy.deepcopy(_MUTATION_REPRO_EXPECTED)
+    actual = copy.deepcopy(_MUTATION_REPRO_ACTUAL)
+    before = copy.deepcopy(expected)
+    actual_before = copy.deepcopy(actual)
+
+    json_subset_match_score(expected, actual)
+
+    assert expected == before
+    assert actual == actual_before
+
+
+def test_repeated_scoring_of_same_objects_is_stable() -> None:
+    """Two consecutive scores of the same objects must agree. Pre-fix the first
+    call stripped `check.check_number` from the ground truth, so the second call
+    saw a GT with no check_number at all and scored the wrong prediction 1.0."""
+    expected = copy.deepcopy(_MUTATION_REPRO_EXPECTED)
+    actual = copy.deepcopy(_MUTATION_REPRO_ACTUAL)
+
+    first = json_subset_match_score(expected, actual)
+    second = json_subset_match_score(expected, actual)
+
+    assert first == second, f"repeated scoring drifted: {first} -> {second}"
+    assert first == 0.0, f"wrong check_number should score 0.0, got {first}"
+
+
+def test_scoring_does_not_mutate_expected_for_checks_plural_shape() -> None:
+    """Same guarantee for the legacy `checks: [<dict>]` shape, whose entry dict
+    is also aliased out of the caller's input before the check_number lift."""
+    expected = {"payment_details": [{"checks": [{"check_number": "12345", "check_amount": 100.0}]}]}
+    actual = {"payment_details": [{"check_number": "99999", "check": {"check_amount": 100.0}}]}
+    before = copy.deepcopy(expected)
+
+    first = json_subset_match_score(expected, actual)
+    second = json_subset_match_score(expected, actual)
+
+    assert expected == before
+    assert first == second
+
+
+# normalize_field_aliases: the back-compat rewrites applied to both sides
+# before comparison. Exercised directly so a change to one alias shape can't
+# ride in behind an end-to-end score assertion.
+
+
+def test_normalize_field_aliases_renames_rendering_provider_npi() -> None:
+    normalized = normalize_field_aliases(
+        {"claims": [{"rendering_provider": {"rendering_provider_identification_number": "1234567893"}}]}
+    )
+    assert normalized == {"claims": [{"rendering_provider": {"provider_npi": "1234567893"}}]}
+
+
+def test_normalize_field_aliases_rewrites_payment_details_shapes() -> None:
+    normalized = normalize_field_aliases(
+        {
+            "payment_details": [
+                {
+                    "checks": [{"check_number": "12345"}],
+                    "check_amount": 100.0,
+                    "check_date": "2026-01-01",
+                    "payment_method": "CHECK",
+                    "provider_id": "1234567893",
+                    "provider_name": "ACME",
+                    "provider_address": "1 Main St",
+                }
+            ]
+        }
+    )
+    assert normalized == {
+        "payment_details": [
+            {
+                "check": {
+                    "check_amount": 100.0,
+                    "check_date": "2026-01-01",
+                    "payment_method": "CHECK",
+                },
+                "check_number": "12345",
+                "payee": {
+                    "payee_npi": "1234567893",
+                    "payee_name": "ACME",
+                    "payee_address": {"payee_address_one": "1 Main St"},
+                },
+            }
+        ]
+    }
+
+
+def test_normalize_field_aliases_prefers_top_level_check_number() -> None:
+    """An already-lifted top-level check_number wins over the nested fallback,
+    and the nested copy is dropped so it isn't scored twice."""
+    normalized = normalize_field_aliases(
+        {"payment_details": [{"check_number": "TOP", "check": {"check_number": "NESTED", "check_amount": 5.0}}]}
+    )
+    assert normalized == {"payment_details": [{"check_number": "TOP", "check": {"check_amount": 5.0}}]}
+
+
+def test_normalize_field_aliases_maps_non_npi_provider_id_to_tin() -> None:
+    normalized = normalize_field_aliases({"payment_details": [{"provider_id": "12-3456789"}]})
+    assert normalized == {"payment_details": [{"payee": {"payee_tin": "12-3456789"}}]}
+
+
+def test_normalize_field_aliases_leaves_unrelated_values_untouched() -> None:
+    payload = {"claims": [{"claim_number": "A1", "amount": 100.0}], "notes": None, "tags": ["x", "y"]}
+    assert normalize_field_aliases(payload) == payload
+
+
+def test_empty_expected_list_against_populated_actual() -> None:
+    """Weighted (the default) keeps subset semantics — an empty expected list
+    makes no claim about what the extractor returned. Unweighted mirrors
+    upstream scoring and penalizes the over-extraction."""
+    expected: dict[str, Any] = {"claims": []}
+    actual: dict[str, Any] = {"claims": [{"claim_number": "A1"}, {"claim_number": "A2"}]}
+
+    assert json_subset_match_score(expected, actual, weighted=True) == 1.0
+    assert json_subset_match_score(expected, actual, weighted=False) == 0.0
+    # Both empty still matches in either mode.
+    assert json_subset_match_score(expected, {"claims": []}, weighted=False) == 1.0
+
 
 _NULLABLE_NUMERIC_SCHEMA: dict[str, Any] = {
     "anyOf": [{"type": "number"}, {"type": "null"}],

--- a/tests/extract_bench/evaluation/metrics/extract/test_list_unwrap.py
+++ b/tests/extract_bench/evaluation/metrics/extract/test_list_unwrap.py
@@ -1,0 +1,274 @@
+"""Unit tests for the list-root unwrap helper used by per_table_row pipelines."""
+
+from __future__ import annotations
+
+from extract_bench.evaluation.metrics.extract.list_unwrap import (
+    infer_array_field,
+    normalize_list_prediction,
+    unwrap_list_prediction,
+)
+from extract_bench.test_cases.schema import ExtractFieldTestRule
+
+
+def _rule(field_path: str, value: str | int | float | bool | None = "x") -> ExtractFieldTestRule:
+    return ExtractFieldTestRule(field_path=field_path, expected_value=value)
+
+
+def test_dict_rooted_prediction_is_passthrough() -> None:
+    """Per_doc predictions already have a dict root — unwrap must be a no-op."""
+    rules = [_rule("personnel[0].name", "Alice"), _rule("client_id", "C-1")]
+    extracted = {"personnel": [{"name": "Alice"}], "client_id": "C-1"}
+
+    result, applied, skipped = unwrap_list_prediction(extracted, rules)
+
+    assert result is extracted
+    assert applied is False
+    assert skipped == []
+
+
+def test_list_rooted_prediction_all_rules_same_array_prefix() -> None:
+    """All rules under one array — wrap, no skipped scalars."""
+    rules = [
+        _rule("personnel[0].name", "Alice"),
+        _rule("personnel[1].name", "Bob"),
+        _rule("personnel[0].net_pay", 100),
+    ]
+    extracted = [{"name": "Alice", "net_pay": 100}, {"name": "Bob", "net_pay": 200}]
+
+    result, applied, skipped = unwrap_list_prediction(extracted, rules)
+
+    assert applied is True
+    assert skipped == []
+    assert result == {"personnel": extracted}
+
+
+def test_wrapper_per_row_prediction_is_flattened_to_array_prefix() -> None:
+    """per_table_row can emit document-shaped wrappers; flatten their array field."""
+    rules = [
+        _rule("personnel[0].name", "Alice"),
+        _rule("personnel[1].name", "Bob"),
+        _rule("personnel[0].net_pay", 100),
+        _rule("client_id", "C-1"),
+    ]
+    extracted = [
+        {"client_id": "C-1", "run_number": "R-1", "personnel": [{"name": "Alice", "net_pay": 100}]},
+        {"client_id": "C-1", "run_number": "R-1", "personnel": [{"name": "Bob", "net_pay": 200}]},
+    ]
+
+    result, applied, skipped = unwrap_list_prediction(extracted, rules)
+
+    assert applied is True
+    assert skipped == []
+    assert result == {
+        "client_id": "C-1",
+        "run_number": "R-1",
+        "personnel": [
+            {"name": "Alice", "net_pay": 100},
+            {"name": "Bob", "net_pay": 200},
+        ],
+    }
+
+
+def test_wrapper_per_row_prediction_extends_multi_row_wrappers() -> None:
+    """Flatten all rows if a wrapper carries more than one array item."""
+    rules = [_rule("personnel[0].name", "Alice"), _rule("personnel[1].name", "Bob")]
+    extracted = [
+        {"personnel": [{"name": "Alice"}, {"name": "Bob"}]},
+        {"personnel": []},
+    ]
+
+    result, applied, skipped = unwrap_list_prediction(extracted, rules)
+
+    assert applied is True
+    assert skipped == []
+    assert result == {"personnel": [{"name": "Alice"}, {"name": "Bob"}]}
+
+
+def test_attendance_rules_wrapper_rows_are_flattened() -> None:
+    """Attendance v0.5 shape: one large array plus document-level scalar rules."""
+    rules = [
+        _rule("attendance_records[0].date", "2026-01-01"),
+        _rule("attendance_records[0].clock_on", "09:00"),
+        _rule("attendance_records[0].attendance_type", "Work"),
+        _rule("attendance_records[1].date", "2026-01-02"),
+        _rule("attendance_records[1].clock_off", "17:00"),
+        _rule("employee_name", "Jane Doe"),
+        _rule("period_start_date", "2026-01-01"),
+        _rule("period_end_date", "2026-01-31"),
+    ]
+    extracted = [
+        {
+            "employee_name": "Jane Doe",
+            "period_start_date": "2026-01-01",
+            "period_end_date": "2026-01-31",
+            "attendance_records": [{"date": "2026-01-01", "clock_on": "09:00", "attendance_type": "Work"}],
+        },
+        {
+            "employee_name": "Jane Doe",
+            "period_start_date": "2026-01-01",
+            "period_end_date": "2026-01-31",
+            "attendance_records": [{"date": "2026-01-02", "clock_off": "17:00"}],
+        },
+    ]
+
+    result, applied, skipped = unwrap_list_prediction(extracted, rules)
+
+    assert applied is True
+    assert skipped == []
+    assert result == {
+        "employee_name": "Jane Doe",
+        "period_start_date": "2026-01-01",
+        "period_end_date": "2026-01-31",
+        "attendance_records": [
+            {"date": "2026-01-01", "clock_on": "09:00", "attendance_type": "Work"},
+            {"date": "2026-01-02", "clock_off": "17:00"},
+        ],
+    }
+
+
+def test_mixed_wrapper_shape_merges_available_arrays_and_scalars() -> None:
+    """Wrapper merge keeps rows that are present and preserves scalar fields."""
+    rules = [_rule("personnel[0].name", "Alice")]
+    extracted = [
+        {"personnel": [{"name": "Alice"}]},
+        {"name": "Bob"},
+    ]
+
+    result, applied, skipped = unwrap_list_prediction(extracted, rules)
+
+    assert applied is True
+    assert skipped == []
+    assert result == {"personnel": [{"name": "Alice"}], "name": "Bob"}
+
+
+def test_list_rooted_prediction_skips_scalar_rules() -> None:
+    """Scalar rules (no array index) are reported as skipped, not scored."""
+    rules = [
+        _rule("personnel[0].name", "Alice"),
+        _rule("personnel[1].name", "Bob"),
+        _rule("client_id", "C-1"),
+        _rule("buyer.company", "Acme"),
+    ]
+    extracted = [{"name": "Alice"}, {"name": "Bob"}]
+
+    result, applied, skipped = unwrap_list_prediction(extracted, rules)
+
+    assert applied is True
+    assert set(skipped) == {"client_id", "buyer.company"}
+    assert result == {"personnel": extracted}
+
+
+def test_list_rooted_prediction_multiple_array_prefixes_is_ambiguous() -> None:
+    """Rules split across two top-level arrays — cannot safely unwrap."""
+    rules = [
+        _rule("personnel[0].name", "Alice"),
+        _rule("transactions[0].amount", 50),
+    ]
+    extracted = [{"name": "Alice"}, {"name": "Bob"}]
+
+    result, applied, skipped = unwrap_list_prediction(extracted, rules)
+
+    assert result is extracted
+    assert applied is False
+    assert skipped == []
+
+
+def test_multi_array_wrapper_prediction_merges_all_arrays() -> None:
+    """DataSnipper bank statements can emit wrappers with several arrays."""
+    rules = [
+        _rule("checks_paid[0].amount", 10),
+        _rule("electronic_debits_bank_debits[0].amount", 20),
+        _rule("account_number", "123"),
+    ]
+    extracted = [
+        {
+            "account_number": "123",
+            "checks_paid": [{"amount": 10}],
+            "electronic_debits_bank_debits": [],
+        },
+        {
+            "account_number": "123",
+            "checks_paid": [],
+            "electronic_debits_bank_debits": [{"amount": 20}],
+        },
+    ]
+
+    result, applied, skipped = unwrap_list_prediction(extracted, rules)
+
+    assert applied is True
+    assert skipped == []
+    assert result == {
+        "account_number": "123",
+        "checks_paid": [{"amount": 10}],
+        "electronic_debits_bank_debits": [{"amount": 20}],
+    }
+
+
+def test_singleton_scalar_doc_list_is_unwrapped() -> None:
+    """Scalar-only per-doc responses can arrive wrapped in a singleton list."""
+    rules = [_rule("tax_year", "2024"), _rule("employee_name", "Jane Doe")]
+    extracted = [{"tax_year": "2024", "employee_name": "Jane Doe"}]
+
+    result, applied, skipped = unwrap_list_prediction(extracted, rules)
+
+    assert applied is True
+    assert skipped == []
+    assert result == {"tax_year": "2024", "employee_name": "Jane Doe"}
+
+
+def test_case_only_alias_is_skipped_using_schema_canonical_key() -> None:
+    """If schema only defines Employee, lowercase duplicate rules are aliases."""
+    rules = [
+        _rule("Employee[0].Name", "Alice"),
+        _rule("employee[0].Name", "Alice"),
+    ]
+    extracted = [{"Employee": [{"Name": "Alice"}]}]
+
+    normalized = normalize_list_prediction(
+        extracted,
+        rules,
+        data_schema={"type": "object", "properties": {"Employee": {"type": "array"}}},
+    )
+
+    assert normalized.applied is True
+    assert normalized.mode == "wrapper_merge"
+    assert normalized.alias_skipped_field_paths == ["employee[0].Name"]
+    assert normalized.extracted_data == {"Employee": [{"Name": "Alice"}]}
+
+
+def test_list_rooted_prediction_all_rules_scalar_unwraps_singleton_doc() -> None:
+    """Scalar-only rules can score against a singleton document list."""
+    rules = [_rule("client_id", "C-1"), _rule("buyer.company", "Acme")]
+    extracted = [{"anything": 1}]
+
+    result, applied, skipped = unwrap_list_prediction(extracted, rules)
+
+    assert result == {"anything": 1}
+    assert applied is True
+    assert skipped == []
+
+
+def test_empty_rule_list_is_passthrough() -> None:
+    """No rules → nothing to infer from; leave the prediction untouched."""
+    extracted: list[dict[str, int]] = [{"a": 1}]
+
+    result, applied, skipped = unwrap_list_prediction(extracted, [])
+
+    assert result is extracted
+    assert applied is False
+    assert skipped == []
+
+
+def test_infer_array_field_single_prefix() -> None:
+    rules = [_rule("personnel[0].name"), _rule("personnel[1].net_pay")]
+    assert infer_array_field(rules) == "personnel"
+
+
+def test_infer_array_field_no_array_rooted_returns_none() -> None:
+    rules = [_rule("client_id"), _rule("buyer.company")]
+    assert infer_array_field(rules) is None
+
+
+def test_infer_array_field_multiple_prefixes_returns_none() -> None:
+    rules = [_rule("personnel[0].name"), _rule("transactions[0].amount")]
+    assert infer_array_field(rules) is None

--- a/tests/extract_bench/test_cases/test_extract_field_rules.py
+++ b/tests/extract_bench/test_cases/test_extract_field_rules.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import ValidationError
 
 from extract_bench.test_cases.schema import (
+    EVIDENCE_LAYERS,
     ExtractFieldBbox,
     ExtractFieldTestRule,
     ExtractTestCase,
@@ -87,7 +88,7 @@ def test_rule_with_bboxes_round_trip() -> None:
             ExtractFieldBbox(page=1, bbox=[0.1, 0.5, 0.3, 0.4], source_bbox_index=1),
         ],
         verified=False,
-        tags=["source_export"],
+        tags=["sample"],
     )
     payload = rule.model_dump()
     restored = ExtractFieldTestRule.model_validate(payload)
@@ -108,6 +109,39 @@ def test_rule_accepts_value_only_evidence_without_page() -> None:
 
     assert rule.evidence is not None
     assert rule.evidence[0].page is None
+    assert rule.evidence[0].layer is None
+
+
+def test_evidence_layer_defaults_to_none() -> None:
+    evidence = FieldEvidence(page=1, bbox=[0.1, 0.1, 0.2, 0.05], value="Acme")
+    assert evidence.layer is None
+
+
+def test_evidence_layer_accepts_known_names() -> None:
+    assert EVIDENCE_LAYERS == frozenset({"word", "structural", "checkbox", "checkbox_label", "checkbox_with_label"})
+    word = FieldEvidence(page=1, bbox=[0.1, 0.1, 0.2, 0.05], value="Acme", layer="word")
+    structural = FieldEvidence(page=1, bbox=[0.05, 0.05, 0.4, 0.1], value="Acme", layer="structural")
+    assert word.layer == "word"
+    assert structural.layer == "structural"
+    for name in ("checkbox", "checkbox_label", "checkbox_with_label"):
+        assert FieldEvidence(page=1, bbox=[0.1, 0.1, 0.02, 0.02], value=True, layer=name).layer == name
+
+
+def test_evidence_layer_rejects_unknown_names() -> None:
+    with pytest.raises(ValidationError, match="Unknown evidence layer"):
+        FieldEvidence(page=1, bbox=[0.1, 0.1, 0.2, 0.05], value="Acme", layer="word-tight")
+
+
+def test_evidence_layer_round_trips_on_rule() -> None:
+    rule = ExtractFieldTestRule(
+        field_path="field_name",
+        evidence=[
+            FieldEvidence(page=1, bbox=[0.1, 0.1, 0.2, 0.05], value="Acme", layer="word"),
+        ],
+    )
+    restored = ExtractFieldTestRule.model_validate(rule.model_dump())
+    assert restored.evidence is not None
+    assert restored.evidence[0].layer == "word"
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Bottom of a five-PR stack (#45 → #46 → #47 → #48 → #49) that brings the extract lane to parity with the internal harness ahead of the first `extract-bench` PyPI release. Rebased onto #38/#39/#41/#43; the value-F1, envelope grounding and adapter ports that those PRs already landed were dropped from this branch.

## Summary
- JSON subset match: ground truth is no longer mutated during scoring (a second pass over the same objects saw a stripped nested `check_number`). Unweighted mode scores an empty expected list against a non-empty actual list as 0.
- `FieldEvidence.layer`: accepted and validated at load time so ground truth written for the internal harness loads unchanged. Headline grounded F1 ORs every box regardless of layer; per-layer metrics stay in the internal evaluator.
- `test_rules` entries typed `layout_line` / `layout_word` load as layout rules with the matching granularity.
- Adds `CHANGELOG.md` (Keep a Changelog) describing everything unreleased on `main` plus this stack.

## Test plan
- [x] The internal harness's own `test_unified_evidence_metric.py` run against `main`'s scorer: 84 pass, the 5 failures are all per-layer grounding
- [x] Full suite green on the stack top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EF1LA2jjajn6362TPkBLaC